### PR TITLE
feat!(ad_group_membership): make membership writes immune to member renames

### DIFF
--- a/docs/resources/group_membership.md
+++ b/docs/resources/group_membership.md
@@ -4,7 +4,7 @@ page_title: "ad_group_membership Resource - ad"
 subcategory: ""
 description: |-
   Manages the membership of an Active Directory group. This resource allows you to define the complete set of members for a group, with automatic anti-drift protection through identifier normalization.
-  Anti-Drift Protection: This resource automatically normalizes all member identifiers to distinguished names (DNs) and object GUIDs internally while preserving your original configuration. The members attribute retains exactly what you configure, while member_details shows the resolved (dn, guid) pairs used for Active Directory operations. Resolution happens once, at plan time; because an object's objectGUID never changes for its lifetime (unlike its DN, which changes on rename), that plan-time snapshot is trusted for the rest of the apply.
+  Anti-Drift Protection: This resource automatically normalizes all member identifiers to distinguished names (DNs) and object GUIDs internally while preserving your original configuration. The members attribute retains exactly what you configure, while member_details shows the resolved (dn, id) pairs used for Active Directory operations. Resolution happens once, at plan time; because an object's objectGUID never changes for its lifetime (unlike its DN, which changes on rename), that plan-time snapshot is trusted for the rest of the apply.
   Supported Identifier Formats:
   Distinguished Name (DN): CN=John Doe,OU=Users,DC=example,DC=comObject GUID: 550e8400-e29b-41d4-a716-446655440000User Principal Name (UPN): john@example.comSAM Account Name: DOMAIN\john or johnSecurity Identifier (SID): S-1-5-21-123456789-123456789-123456789-1001
 ---
@@ -13,7 +13,7 @@ description: |-
 
 Manages the membership of an Active Directory group. This resource allows you to define the complete set of members for a group, with automatic anti-drift protection through identifier normalization.
 
-**Anti-Drift Protection**: This resource automatically normalizes all member identifiers to distinguished names (DNs) and object GUIDs internally while preserving your original configuration. The `members` attribute retains exactly what you configure, while `member_details` shows the resolved `(dn, guid)` pairs used for Active Directory operations. Resolution happens once, at plan time; because an object's `objectGUID` never changes for its lifetime (unlike its DN, which changes on rename), that plan-time snapshot is trusted for the rest of the apply.
+**Anti-Drift Protection**: This resource automatically normalizes all member identifiers to distinguished names (DNs) and object GUIDs internally while preserving your original configuration. The `members` attribute retains exactly what you configure, while `member_details` shows the resolved `(dn, id)` pairs used for Active Directory operations. Resolution happens once, at plan time; because an object's `objectGUID` never changes for its lifetime (unlike its DN, which changes on rename), that plan-time snapshot is trusted for the rest of the apply.
 
 **Supported Identifier Formats**:
 - Distinguished Name (DN): `CN=John Doe,OU=Users,DC=example,DC=com`
@@ -103,7 +103,7 @@ If not specified, inherits from the provider-level `ignore_missing_members` sett
 Read-Only:
 
 - `dn` (String) The member's distinguished name.
-- `guid` (String) The member's objectGUID (canonical hyphenated form).
+- `id` (String) The member's objectGUID (canonical hyphenated form).
 
 ## Import
 

--- a/docs/resources/group_membership.md
+++ b/docs/resources/group_membership.md
@@ -4,7 +4,7 @@ page_title: "ad_group_membership Resource - ad"
 subcategory: ""
 description: |-
   Manages the membership of an Active Directory group. This resource allows you to define the complete set of members for a group, with automatic anti-drift protection through identifier normalization.
-  Anti-Drift Protection: This resource automatically normalizes all member identifiers to distinguished names (DNs) internally while preserving your original configuration. The members attribute retains exactly what you configure, while members_normalized shows the DNs used for Active Directory operations.
+  Anti-Drift Protection: This resource automatically normalizes all member identifiers to distinguished names (DNs) and object GUIDs internally while preserving your original configuration. The members attribute retains exactly what you configure, while member_details shows the resolved (dn, guid) pairs used for Active Directory operations. Resolution happens once, at plan time; because an object's objectGUID never changes for its lifetime (unlike its DN, which changes on rename), that plan-time snapshot is trusted for the rest of the apply.
   Supported Identifier Formats:
   Distinguished Name (DN): CN=John Doe,OU=Users,DC=example,DC=comObject GUID: 550e8400-e29b-41d4-a716-446655440000User Principal Name (UPN): john@example.comSAM Account Name: DOMAIN\john or johnSecurity Identifier (SID): S-1-5-21-123456789-123456789-123456789-1001
 ---
@@ -13,7 +13,7 @@ description: |-
 
 Manages the membership of an Active Directory group. This resource allows you to define the complete set of members for a group, with automatic anti-drift protection through identifier normalization.
 
-**Anti-Drift Protection**: This resource automatically normalizes all member identifiers to distinguished names (DNs) internally while preserving your original configuration. The `members` attribute retains exactly what you configure, while `members_normalized` shows the DNs used for Active Directory operations.
+**Anti-Drift Protection**: This resource automatically normalizes all member identifiers to distinguished names (DNs) and object GUIDs internally while preserving your original configuration. The `members` attribute retains exactly what you configure, while `member_details` shows the resolved `(dn, guid)` pairs used for Active Directory operations. Resolution happens once, at plan time; because an object's `objectGUID` never changes for its lifetime (unlike its DN, which changes on rename), that plan-time snapshot is trusted for the rest of the apply.
 
 **Supported Identifier Formats**:
 - Distinguished Name (DN): `CN=John Doe,OU=Users,DC=example,DC=com`
@@ -95,7 +95,15 @@ If not specified, inherits from the provider-level `ignore_missing_members` sett
 ### Read-Only
 
 - `id` (String) The resource identifier, which is the objectGUID of the group. This is the same value as `group_id`.
-- `members_normalized` (Set of String) The normalized distinguished names (DNs) of all group members. This computed attribute shows the actual DNs used for Active Directory operations, derived from the identifiers specified in the `members` attribute.
+- `member_details` (Attributes Set) The resolved identity of every group member: its distinguished name (DN) and object GUID, both derived from whatever identifier format was used in `members`. This is the authoritative source used for all Active Directory operations — resolved once, at plan time, and immune to the member being renamed afterward (the GUID never changes even when the DN does). (see [below for nested schema](#nestedatt--member_details))
+
+<a id="nestedatt--member_details"></a>
+### Nested Schema for `member_details`
+
+Read-Only:
+
+- `dn` (String) The member's distinguished name.
+- `guid` (String) The member's objectGUID (canonical hyphenated form).
 
 ## Import
 

--- a/internal/ldap/dn_normalizer.go
+++ b/internal/ldap/dn_normalizer.go
@@ -83,9 +83,21 @@ func NormalizeDNCaseBatch(dns []string) ([]string, error) {
 }
 
 // ValidateDNSyntax validates that a string is a properly formatted Distinguished Name.
+//
+// As a special case, it also accepts AD's "<GUID=...>" alternative-DN form
+// (see GUIDToAltDN): rather than parsing it as an RFC 4514 DN (which it is
+// not), the enclosed GUID's shape is validated directly.
 func ValidateDNSyntax(dn string) error {
 	if dn == "" {
 		return fmt.Errorf("DN cannot be empty")
+	}
+
+	if IsAltGUIDDN(dn) {
+		matches := altGUIDDNRegex.FindStringSubmatch(strings.TrimSpace(dn))
+		if len(matches) != 2 || !NewGUIDHandler().IsValidGUID(matches[1]) {
+			return fmt.Errorf("invalid GUID in alternative DN: %s", dn)
+		}
+		return nil
 	}
 
 	_, err := ldap.ParseDN(dn)

--- a/internal/ldap/dn_normalizer_test.go
+++ b/internal/ldap/dn_normalizer_test.go
@@ -252,6 +252,16 @@ func TestValidateDNSyntax(t *testing.T) {
 			input:   "cn=john,doe,ou=users,dc=example,dc=com",
 			wantErr: true,
 		},
+		{
+			name:    "well-formed alternative GUID DN",
+			input:   "<GUID=12345678-1234-1234-1234-123456789012>",
+			wantErr: false,
+		},
+		{
+			name:    "malformed alternative GUID DN",
+			input:   "<GUID=not-a-guid>",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -264,6 +274,37 @@ func TestValidateDNSyntax(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestValidateDNSyntax_AltGUIDDN covers the "<GUID=...>" alternative-DN form
+// (see GUIDToAltDN) in more detail than the table-driven cases above:
+// well-formed values are accepted, malformed ones are rejected with a
+// specific error, and ordinary DN validation is unaffected.
+func TestValidateDNSyntax_AltGUIDDN(t *testing.T) {
+	t.Run("accepts compact GUID inside the delimiters", func(t *testing.T) {
+		err := ValidateDNSyntax("<GUID=12345678123412341234123456789012>")
+		assert.NoError(t, err)
+	})
+
+	t.Run("accepts uppercase GUID keyword", func(t *testing.T) {
+		err := ValidateDNSyntax("<guid=12345678-1234-1234-1234-123456789012>")
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects empty GUID content", func(t *testing.T) {
+		err := ValidateDNSyntax("<GUID=>")
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects garbage GUID content", func(t *testing.T) {
+		err := ValidateDNSyntax("<GUID=zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz>")
+		assert.Error(t, err)
+	})
+
+	t.Run("plain DN validation is unaffected", func(t *testing.T) {
+		assert.NoError(t, ValidateDNSyntax("cn=john,ou=users,dc=example,dc=com"))
+		assert.Error(t, ValidateDNSyntax("not-a-dn-and-not-alt-guid"))
+	})
 }
 
 func TestExtractRDNValue(t *testing.T) {

--- a/internal/ldap/doc.go
+++ b/internal/ldap/doc.go
@@ -86,7 +86,7 @@ Connection pooling handles concurrent access automatically.
 
 	// Manage group membership
 	membershipManager := ldap.NewGroupMembershipManager(ctx, client, "DC=example,DC=com", nil)
-	err = membershipManager.SetGroupMembers(ctx, groupGUID, memberDNs)
+	err = membershipManager.SetGroupMembers(groupGUID, memberDNs, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/ldap/group.go
+++ b/internal/ldap/group.go
@@ -773,7 +773,7 @@ func (gm *GroupManager) AddMembers(groupGUID string, members []string) error {
 	}
 
 	// Normalize member identifiers to DNs
-	memberDNs, failures := gm.normalizer.NormalizeToDNBatch(members)
+	resolvedMembers, failures := gm.normalizer.ResolveBatch(members)
 
 	// In LDAP operations, any normalization failure is an error
 	if len(failures) > 0 {
@@ -787,9 +787,9 @@ func (gm *GroupManager) AddMembers(groupGUID string, members []string) error {
 	}
 
 	// Extract just the DN values
-	dnList := make([]string, 0, len(memberDNs))
-	for _, dn := range memberDNs {
-		dnList = append(dnList, dn)
+	dnList := make([]string, 0, len(resolvedMembers))
+	for _, r := range resolvedMembers {
+		dnList = append(dnList, r.DN)
 	}
 
 	// Add members using LDAP modify operation
@@ -827,7 +827,7 @@ func (gm *GroupManager) RemoveMembers(groupGUID string, members []string) error 
 	}
 
 	// Normalize member identifiers to DNs
-	memberDNs, failures := gm.normalizer.NormalizeToDNBatch(members)
+	resolvedMembers, failures := gm.normalizer.ResolveBatch(members)
 
 	// In LDAP operations, any normalization failure is an error
 	if len(failures) > 0 {
@@ -841,9 +841,9 @@ func (gm *GroupManager) RemoveMembers(groupGUID string, members []string) error 
 	}
 
 	// Extract just the DN values
-	dnList := make([]string, 0, len(memberDNs))
-	for _, dn := range memberDNs {
-		dnList = append(dnList, dn)
+	dnList := make([]string, 0, len(resolvedMembers))
+	for _, r := range resolvedMembers {
+		dnList = append(dnList, r.DN)
 	}
 
 	// Remove members using LDAP modify operation

--- a/internal/ldap/guid.go
+++ b/internal/ldap/guid.go
@@ -294,3 +294,40 @@ func (g *GUIDHandler) ParseGUIDFromDN(dn string) (string, bool) {
 
 	return "", false
 }
+
+// altGUIDDNRegex recognises the "<GUID=...>" alternative-DN shape documented
+// by MS-ADTS, without validating the content between the delimiters. Use
+// IsAltGUIDDN for the shape check and GUIDToAltDN to build/validate a real one.
+var altGUIDDNRegex = regexp.MustCompile(`(?i)^<GUID=(.*)>$`)
+
+// GUIDToAltDN builds the AD "alternative DN" form of a GUID: "<GUID=object_guid>".
+//
+// Per MS-ADTS (3.1.1.3.1.3), Active Directory accepts this form anywhere a DN
+// is expected in a client request - including as an AttributeValue in a
+// ModifyRequest - and resolves it to the object with that objectGUID,
+// regardless of the object's current name/location. This makes it immune to
+// concurrent renames that would otherwise invalidate a literal DN captured
+// earlier (e.g. at Terraform plan time).
+//
+// MS-ADTS permits either the hex-encoded binary GUID or, on Windows Server
+// 2003 and later, the standard dashed-string GUID form inside the angle
+// brackets. This implementation always emits the dashed-string form (matching
+// NormalizeGUID's canonical output) for consistency with the rest of this
+// file and for human-readable request/log inspection; both forms are
+// equally valid on the wire.
+func GUIDToAltDN(guid string) (string, error) {
+	handler := NewGUIDHandler()
+	normalized, err := handler.NormalizeGUID(guid)
+	if err != nil {
+		return "", fmt.Errorf("invalid GUID for alternative DN: %w", err)
+	}
+	return fmt.Sprintf("<GUID=%s>", normalized), nil
+}
+
+// IsAltGUIDDN reports whether s has the "<GUID=...>" alternative-DN shape.
+// It only recognises the shape (delimiters present); it does not validate
+// that the enclosed value is actually a well-formed GUID - use GUIDToAltDN
+// or NewGUIDHandler().IsValidGUID on the extracted value for that.
+func IsAltGUIDDN(s string) bool {
+	return altGUIDDNRegex.MatchString(strings.TrimSpace(s))
+}

--- a/internal/ldap/guid_test.go
+++ b/internal/ldap/guid_test.go
@@ -722,6 +722,116 @@ func TestGUIDHandler_ParseGUIDFromDN(t *testing.T) {
 	}
 }
 
+func TestGUIDToAltDN(t *testing.T) {
+	tests := []struct {
+		name     string
+		guid     string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "hyphenated GUID",
+			guid:     "12345678-1234-1234-1234-123456789012",
+			expected: "<GUID=12345678-1234-1234-1234-123456789012>",
+		},
+		{
+			name:     "compact GUID is normalized to hyphenated form",
+			guid:     "12345678123412341234123456789012",
+			expected: "<GUID=12345678-1234-1234-1234-123456789012>",
+		},
+		{
+			name:     "mixed-case GUID is normalized to lowercase",
+			guid:     "ABCDEF01-1234-1234-1234-123456789012",
+			expected: "<GUID=abcdef01-1234-1234-1234-123456789012>",
+		},
+		{
+			name:    "malformed GUID rejected",
+			guid:    "not-a-guid",
+			wantErr: true,
+		},
+		{
+			name:    "empty GUID rejected",
+			guid:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := GUIDToAltDN(tt.guid)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Empty(t, result)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsAltGUIDDN(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "well-formed alternative DN",
+			input:    "<GUID=12345678-1234-1234-1234-123456789012>",
+			expected: true,
+		},
+		{
+			name:     "malformed content still recognised as the shape",
+			input:    "<GUID=not-a-guid>",
+			expected: true,
+		},
+		{
+			name:     "lowercase guid keyword",
+			input:    "<guid=12345678-1234-1234-1234-123456789012>",
+			expected: true,
+		},
+		{
+			name:     "padded with whitespace",
+			input:    "  <GUID=12345678-1234-1234-1234-123456789012>  ",
+			expected: true,
+		},
+		{
+			name:     "plain DN",
+			input:    "CN=User,OU=Users,DC=example,DC=com",
+			expected: false,
+		},
+		{
+			name:     "missing closing bracket",
+			input:    "<GUID=12345678-1234-1234-1234-123456789012",
+			expected: false,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsAltGUIDDN(tt.input))
+		})
+	}
+}
+
+func TestGUIDToAltDN_IsAltGUIDDN_RoundTrip(t *testing.T) {
+	guid := "12345678-1234-1234-1234-123456789012"
+
+	altDN, err := GUIDToAltDN(guid)
+	require.NoError(t, err)
+
+	assert.True(t, IsAltGUIDDN(altDN))
+	assert.False(t, IsAltGUIDDN(guid), "the bare GUID itself is not the alternative-DN shape")
+}
+
 // Benchmark tests for performance validation.
 func BenchmarkGUIDHandler_StringToGUIDBytes(b *testing.B) {
 	handler := NewGUIDHandler()

--- a/internal/ldap/membership.go
+++ b/internal/ldap/membership.go
@@ -60,7 +60,13 @@ func (gmm *GroupMembershipManager) SetTimeout(timeout time.Duration) {
 
 // SetGroupMembers sets the complete membership of a group, replacing all existing members.
 // All members must be provided as Distinguished Names (DNs).
-func (gmm *GroupMembershipManager) SetGroupMembers(groupGUID string, memberDNs []string) error {
+//
+// memberGUIDs is optional (nil is valid and preserves today's literal-DN
+// write behavior exactly) — DN → canonical GUID, for any member about to
+// be added whose GUID is known. Only consulted by the Add path; Remove
+// already operates on AD's own fresh current DNs via replaceMemberList and
+// has no staleness to guard against.
+func (gmm *GroupMembershipManager) SetGroupMembers(groupGUID string, memberDNs []string, memberGUIDs map[string]string) error {
 	if groupGUID == "" {
 		return fmt.Errorf("group GUID cannot be empty")
 	}
@@ -89,7 +95,7 @@ func (gmm *GroupMembershipManager) SetGroupMembers(groupGUID string, memberDNs [
 	}
 
 	if len(delta.ToAdd) > 0 {
-		if err := gmm.AddGroupMembers(groupGUID, delta.ToAdd); err != nil {
+		if err := gmm.AddGroupMembers(groupGUID, delta.ToAdd, memberGUIDs); err != nil {
 			return WrapError("add_members_for_set", err)
 		}
 	}
@@ -123,7 +129,13 @@ func (gmm *GroupMembershipManager) GetGroupMembers(groupGUID string) ([]string, 
 // AddGroupMembers adds new members to a group using batch operations.
 // All members must be provided as Distinguished Names (DNs).
 // Uses ADMemberBatchSize to respect Active Directory's member operation limits.
-func (gmm *GroupMembershipManager) AddGroupMembers(groupGUID string, memberDNs []string) error {
+//
+// memberGUIDs is optional (nil is valid and preserves today's literal-DN
+// write behavior exactly) — DN → canonical GUID, for any member about to
+// be added whose GUID is known. When present for a given DN, the member is
+// written to AD using its rename-immune "<GUID=...>" alternative-DN form
+// (see GUIDToAltDN) instead of the literal DN.
+func (gmm *GroupMembershipManager) AddGroupMembers(groupGUID string, memberDNs []string, memberGUIDs map[string]string) error {
 	if groupGUID == "" {
 		return fmt.Errorf("group GUID cannot be empty")
 	}
@@ -150,7 +162,7 @@ func (gmm *GroupMembershipManager) AddGroupMembers(groupGUID string, memberDNs [
 	}
 
 	// Perform batch add operations respecting AD limits
-	return gmm.batchAddMembers(group.DistinguishedName, uniqueDNs)
+	return gmm.batchAddMembers(group.DistinguishedName, uniqueDNs, memberGUIDs)
 }
 
 // RemoveGroupMembers removes members from a group using batch operations.
@@ -224,14 +236,14 @@ func (gmm *GroupMembershipManager) CalculateMembershipDelta(groupGUID string, de
 }
 
 // batchAddMembers adds members in batches to respect Active Directory limits.
-func (gmm *GroupMembershipManager) batchAddMembers(groupDN string, memberDNs []string) error {
+func (gmm *GroupMembershipManager) batchAddMembers(groupDN string, memberDNs []string, memberGUIDs map[string]string) error {
 	batchSize := ADMemberBatchSize
 
 	for i := 0; i < len(memberDNs); i += batchSize {
 		end := min(i+batchSize, len(memberDNs))
 
 		batch := memberDNs[i:end]
-		if err := gmm.addMembersBatch(groupDN, batch); err != nil {
+		if err := gmm.addMembersBatch(groupDN, batch, memberGUIDs); err != nil {
 			return fmt.Errorf("failed to add member batch %d-%d: %w", i+1, end, err)
 		}
 	}
@@ -239,22 +251,46 @@ func (gmm *GroupMembershipManager) batchAddMembers(groupDN string, memberDNs []s
 	return nil
 }
 
+// memberWriteValue returns the value to write to AD's member attribute for
+// the given DN: its "<GUID=...>" alternative-DN form when memberGUIDs
+// supplies a GUID for it (falling back to the literal DN if the GUID turns
+// out to be malformed), otherwise the literal DN unchanged.
+func memberWriteValue(dn string, memberGUIDs map[string]string) string {
+	if memberGUIDs == nil {
+		return dn
+	}
+	guid, ok := memberGUIDs[dn]
+	if !ok || guid == "" {
+		return dn
+	}
+	altDN, err := GUIDToAltDN(guid)
+	if err != nil {
+		return dn
+	}
+	return altDN
+}
+
 // addMembersBatch adds a single batch of members with conflict handling.
-func (gmm *GroupMembershipManager) addMembersBatch(groupDN string, memberDNs []string) error {
+func (gmm *GroupMembershipManager) addMembersBatch(groupDN string, memberDNs []string, memberGUIDs map[string]string) error {
 	if len(memberDNs) == 0 {
 		return nil
 	}
 
+	values := make([]string, len(memberDNs))
+	for i, dn := range memberDNs {
+		values[i] = memberWriteValue(dn, memberGUIDs)
+	}
+
 	modReq := &ModifyRequest{
 		DN:            groupDN,
-		AddAttributes: map[string][]string{"member": memberDNs},
+		AddAttributes: map[string][]string{"member": values},
 	}
 
 	err := gmm.client.Modify(gmm.ctx, modReq)
 	if err != nil {
 		// Handle "member already exists" conflicts by adding individually
 		if IsConflictError(err) {
-			return gmm.addMembersIndividually(groupDN, memberDNs)
+			return gmm.addMembersIndividually(groupDN, memberDNs, memberGUIDs)
 		}
 		return err
 	}
@@ -263,14 +299,14 @@ func (gmm *GroupMembershipManager) addMembersBatch(groupDN string, memberDNs []s
 }
 
 // addMembersIndividually adds members one by one to handle conflicts gracefully.
-func (gmm *GroupMembershipManager) addMembersIndividually(groupDN string, memberDNs []string) error {
+func (gmm *GroupMembershipManager) addMembersIndividually(groupDN string, memberDNs []string, memberGUIDs map[string]string) error {
 	var lastNonConflictErr error
 	successCount := 0
 
 	for _, memberDN := range memberDNs {
 		modReq := &ModifyRequest{
 			DN:            groupDN,
-			AddAttributes: map[string][]string{"member": {memberDN}},
+			AddAttributes: map[string][]string{"member": {memberWriteValue(memberDN, memberGUIDs)}},
 		}
 
 		if err := gmm.client.Modify(gmm.ctx, modReq); err != nil {

--- a/internal/ldap/membership_test.go
+++ b/internal/ldap/membership_test.go
@@ -433,7 +433,7 @@ func TestAddGroupMembers(t *testing.T) {
 		user2DN, // DN format
 	}
 
-	err := gmm.AddGroupMembers(groupGUID, membersToAdd)
+	err := gmm.AddGroupMembers(groupGUID, membersToAdd, nil)
 
 	if err != nil {
 		t.Fatalf("AddGroupMembers failed: %v", err)
@@ -471,7 +471,7 @@ func TestAddGroupMembersWithConflicts(t *testing.T) {
 	// Try to add both users (user1 should conflict, user2 should succeed)
 	membersToAdd := []string{user1DN, user2DN}
 
-	err := gmm.AddGroupMembers(groupGUID, membersToAdd)
+	err := gmm.AddGroupMembers(groupGUID, membersToAdd, nil)
 
 	// Should succeed despite conflict (graceful handling)
 	if err != nil {
@@ -480,6 +480,164 @@ func TestAddGroupMembersWithConflicts(t *testing.T) {
 
 	// Verify both members are present
 	expectedMembers := []string{user1DN, user2DN}
+	sort.Strings(group.Members)
+	sort.Strings(expectedMembers)
+
+	if !reflect.DeepEqual(group.Members, expectedMembers) {
+		t.Errorf("Expected members %v, got %v", expectedMembers, group.Members)
+	}
+}
+
+// TestAddGroupMembers_WithMemberGUIDs_UsesAltDNForm verifies that, when a
+// GUID is supplied for a member being added, the value actually written to
+// AD's member attribute is the rename-immune "<GUID=...>" alternative-DN
+// form (see GUIDToAltDN) rather than the literal DN.
+func TestAddGroupMembers_WithMemberGUIDs_UsesAltDNForm(t *testing.T) {
+	gmm, client := createTestMembershipManager(t)
+
+	groupGUID := "12345678-1234-1234-1234-123456789012"
+	groupDN := "CN=TestGroup,OU=Groups,DC=example,DC=com"
+	client.AddMockGroup(groupGUID, groupDN, "TestGroup", "testgroup")
+
+	user1DN := "CN=User1,OU=Users,DC=example,DC=com"
+	user1GUID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	user2DN := "CN=User2,OU=Users,DC=example,DC=com"
+	user2GUID := "11111111-2222-3333-4444-555555555555"
+
+	memberGUIDs := map[string]string{
+		user1DN: user1GUID,
+		user2DN: user2GUID,
+	}
+
+	err := gmm.AddGroupMembers(groupGUID, []string{user1DN, user2DN}, memberGUIDs)
+	if err != nil {
+		t.Fatalf("AddGroupMembers failed: %v", err)
+	}
+
+	expectedUser1AltDN, err := GUIDToAltDN(user1GUID)
+	if err != nil {
+		t.Fatalf("GUIDToAltDN failed: %v", err)
+	}
+	expectedUser2AltDN, err := GUIDToAltDN(user2GUID)
+	if err != nil {
+		t.Fatalf("GUIDToAltDN failed: %v", err)
+	}
+
+	group := client.groups[groupGUID]
+	expectedMembers := []string{expectedUser1AltDN, expectedUser2AltDN}
+	sort.Strings(group.Members)
+	sort.Strings(expectedMembers)
+
+	if !reflect.DeepEqual(group.Members, expectedMembers) {
+		t.Errorf("Expected members written as alt-GUID DNs %v, got %v", expectedMembers, group.Members)
+	}
+
+	// Sanity: the literal DNs must NOT have been used as the write value.
+	for _, m := range group.Members {
+		if m == user1DN || m == user2DN {
+			t.Errorf("Expected alt-GUID DN form, but literal DN %q was written", m)
+		}
+	}
+}
+
+// TestAddGroupMembers_WithMemberGUIDs_FallsBackToLiteralDN verifies that
+// members with no entry in memberGUIDs (or an entirely nil map) are still
+// written using their literal DN, exactly as before this feature existed.
+func TestAddGroupMembers_WithMemberGUIDs_FallsBackToLiteralDN(t *testing.T) {
+	gmm, client := createTestMembershipManager(t)
+
+	groupGUID := "12345678-1234-1234-1234-123456789012"
+	groupDN := "CN=TestGroup,OU=Groups,DC=example,DC=com"
+	client.AddMockGroup(groupGUID, groupDN, "TestGroup", "testgroup")
+
+	user1DN := "CN=User1,OU=Users,DC=example,DC=com"
+	user1GUID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	user2DN := "CN=User2,OU=Users,DC=example,DC=com" // no GUID known for this one
+
+	memberGUIDs := map[string]string{
+		user1DN: user1GUID,
+	}
+
+	err := gmm.AddGroupMembers(groupGUID, []string{user1DN, user2DN}, memberGUIDs)
+	if err != nil {
+		t.Fatalf("AddGroupMembers failed: %v", err)
+	}
+
+	expectedUser1AltDN, err := GUIDToAltDN(user1GUID)
+	if err != nil {
+		t.Fatalf("GUIDToAltDN failed: %v", err)
+	}
+
+	group := client.groups[groupGUID]
+	expectedMembers := []string{expectedUser1AltDN, user2DN}
+	sort.Strings(group.Members)
+	sort.Strings(expectedMembers)
+
+	if !reflect.DeepEqual(group.Members, expectedMembers) {
+		t.Errorf("Expected mixed alt-GUID/literal-DN members %v, got %v", expectedMembers, group.Members)
+	}
+}
+
+// TestAddGroupMembers_NilMemberGUIDs_UsesLiteralDN is a regression guard: a
+// nil memberGUIDs map must preserve the pre-existing literal-DN write
+// behavior exactly (this is also covered implicitly by TestAddGroupMembers,
+// but is asserted explicitly here for clarity).
+func TestAddGroupMembers_NilMemberGUIDs_UsesLiteralDN(t *testing.T) {
+	gmm, client := createTestMembershipManager(t)
+
+	groupGUID := "12345678-1234-1234-1234-123456789012"
+	groupDN := "CN=TestGroup,OU=Groups,DC=example,DC=com"
+	client.AddMockGroup(groupGUID, groupDN, "TestGroup", "testgroup")
+
+	userDN := "CN=User1,OU=Users,DC=example,DC=com"
+
+	if err := gmm.AddGroupMembers(groupGUID, []string{userDN}, nil); err != nil {
+		t.Fatalf("AddGroupMembers failed: %v", err)
+	}
+
+	group := client.groups[groupGUID]
+	if !reflect.DeepEqual(group.Members, []string{userDN}) {
+		t.Errorf("Expected literal DN %q, got %v", userDN, group.Members)
+	}
+}
+
+// TestAddGroupMembers_WithMemberGUIDs_ConflictFallsBackIndividually verifies
+// that the GUID substitution is also applied on the addMembersIndividually
+// conflict-recovery path (triggered when a batch add hits an "already
+// exists" conflict).
+func TestAddGroupMembers_WithMemberGUIDs_ConflictFallsBackIndividually(t *testing.T) {
+	gmm, client := createTestMembershipManager(t)
+
+	groupGUID := "12345678-1234-1234-1234-123456789012"
+	groupDN := "CN=TestGroup,OU=Groups,DC=example,DC=com"
+	client.AddMockGroup(groupGUID, groupDN, "TestGroup", "testgroup")
+
+	user1DN := "CN=User1,OU=Users,DC=example,DC=com"
+	user2DN := "CN=User2,OU=Users,DC=example,DC=com"
+	user2GUID := "11111111-2222-3333-4444-555555555555"
+	client.AddMockObject(user1DN, "", "", "", "user1")
+	client.AddMockObject(user2DN, "", "", "", "user2")
+
+	// Pre-populate group with user1 so the batch add conflicts on it,
+	// forcing the individual-add fallback path for the whole batch.
+	group := client.groups[groupGUID]
+	group.Members = []string{user1DN}
+
+	memberGUIDs := map[string]string{
+		user2DN: user2GUID,
+	}
+
+	err := gmm.AddGroupMembers(groupGUID, []string{user1DN, user2DN}, memberGUIDs)
+	if err != nil {
+		t.Fatalf("AddGroupMembers should handle conflicts gracefully, got error: %v", err)
+	}
+
+	expectedUser2AltDN, err := GUIDToAltDN(user2GUID)
+	if err != nil {
+		t.Fatalf("GUIDToAltDN failed: %v", err)
+	}
+
+	expectedMembers := []string{user1DN, expectedUser2AltDN}
 	sort.Strings(group.Members)
 	sort.Strings(expectedMembers)
 
@@ -666,7 +824,7 @@ func TestSetGroupMembers(t *testing.T) {
 		user2DN, // DN format for user2
 	}
 
-	err := gmm.SetGroupMembers(groupGUID, desiredMembers)
+	err := gmm.SetGroupMembers(groupGUID, desiredMembers, nil)
 
 	if err != nil {
 		t.Fatalf("SetGroupMembers failed: %v", err)
@@ -703,7 +861,7 @@ func TestSetGroupMembersEmptyDesiredList(t *testing.T) {
 	// Set empty membership
 	desiredMembers := []string{}
 
-	err := gmm.SetGroupMembers(groupGUID, desiredMembers)
+	err := gmm.SetGroupMembers(groupGUID, desiredMembers, nil)
 
 	if err != nil {
 		t.Fatalf("SetGroupMembers failed: %v", err)
@@ -879,7 +1037,7 @@ func TestSimplifiedDNOnlyApproach(t *testing.T) {
 	}
 
 	// Test 3: SetGroupMembers should also reject non-DN formats
-	err = gmm.SetGroupMembers(groupGUID, nonDNMembers)
+	err = gmm.SetGroupMembers(groupGUID, nonDNMembers, nil)
 	if err == nil {
 		t.Error("Expected validation error for non-DN format in SetGroupMembers, but got none")
 	} else if !strings.Contains(err.Error(), "invalid member DN") {
@@ -907,7 +1065,7 @@ func TestBatchOperationsLargeSet(t *testing.T) {
 	client.ClearOperationLog()
 
 	// Add all users - should be done in batches
-	err := gmm.AddGroupMembers(groupGUID, largeUserSet)
+	err := gmm.AddGroupMembers(groupGUID, largeUserSet, nil)
 
 	if err != nil {
 		t.Fatalf("AddGroupMembers with large set failed: %v", err)

--- a/internal/ldap/normalizer.go
+++ b/internal/ldap/normalizer.go
@@ -55,6 +55,14 @@ var (
 	samRegex = regexp.MustCompile(`^([^\\@\s]+\\)?[^\\@\s]+$`)
 )
 
+// ResolvedIdentifier is the full result of resolving a DN/GUID/SID/UPN/SAM
+// identifier to the AD object it names. GUID is empty when unavailable
+// (never an error on its own).
+type ResolvedIdentifier struct {
+	DN   string
+	GUID string // canonical hyphenated form
+}
+
 // MemberNormalizer handles normalization of various identifier formats to Distinguished Names.
 type MemberNormalizer struct {
 	client       Client
@@ -118,10 +126,12 @@ func (m *MemberNormalizer) DetectIdentifierType(identifier string) IdentifierTyp
 	return IdentifierTypeUnknown
 }
 
-// NormalizeToDN converts any identifier format to a Distinguished Name.
-func (m *MemberNormalizer) NormalizeToDN(identifier string) (string, error) {
+// Resolve converts any identifier format (DN/GUID/SID/UPN/SAM) to the AD
+// object it names, returning both its Distinguished Name and (when available)
+// its GUID.
+func (m *MemberNormalizer) Resolve(identifier string) (ResolvedIdentifier, error) {
 	if identifier == "" {
-		return "", fmt.Errorf("identifier cannot be empty")
+		return ResolvedIdentifier{}, fmt.Errorf("identifier cannot be empty")
 	}
 
 	identifier = strings.TrimSpace(identifier)
@@ -129,65 +139,67 @@ func (m *MemberNormalizer) NormalizeToDN(identifier string) (string, error) {
 	// Check cache first
 	if m.cacheManager != nil {
 		if cachedEntry, found := m.cacheManager.Get(identifier); found {
-			return cachedEntry.DN, nil
+			return ResolvedIdentifier{DN: cachedEntry.DN, GUID: cachedEntry.ObjectGUID}, nil
 		}
 	}
 
 	// Detect identifier type
 	idType := m.DetectIdentifierType(identifier)
 
-	var dn string
+	var resolved ResolvedIdentifier
 	var err error
 
 	switch idType {
 	case IdentifierTypeDN:
 		// Already a DN, validate and return
-		dn, err = m.validateDN(identifier)
+		resolved, err = m.validateDN(identifier)
 	case IdentifierTypeGUID:
-		dn, err = m.resolveGUIDToDN(identifier)
+		resolved, err = m.resolveGUID(identifier)
 	case IdentifierTypeSID:
-		dn, err = m.ResolveSIDToDN(identifier)
+		resolved, err = m.ResolveSID(identifier)
 	case IdentifierTypeUPN:
-		dn, err = m.resolveUPNToDN(identifier)
+		resolved, err = m.resolveUPN(identifier)
 	case IdentifierTypeSAM:
-		dn, err = m.resolveSAMToDN(identifier)
+		resolved, err = m.resolveSAM(identifier)
 	default:
-		return "", fmt.Errorf("unable to determine identifier type for: %s", identifier)
+		return ResolvedIdentifier{}, fmt.Errorf("unable to determine identifier type for: %s", identifier)
 	}
 
 	if err != nil {
-		return "", fmt.Errorf("failed to normalize identifier '%s' (type: %s): %w", identifier, idType.String(), err)
+		return ResolvedIdentifier{}, fmt.Errorf("failed to normalize identifier '%s' (type: %s): %w", identifier, idType.String(), err)
 	}
 
 	// Apply DN case normalization to ensure uppercase attribute types
-	normalizedDN, err := NormalizeDNCase(dn)
+	normalizedDN, err := NormalizeDNCase(resolved.DN)
 	if err != nil {
-		return "", fmt.Errorf("failed to normalize DN case for '%s': %w", dn, err)
+		return ResolvedIdentifier{}, fmt.Errorf("failed to normalize DN case for '%s': %w", resolved.DN, err)
 	}
+	resolved.DN = normalizedDN
 
 	// Cache the result
 	if m.cacheManager != nil {
 		cacheEntry := &LDAPCacheEntry{
-			DN:         normalizedDN,
-			ObjectGUID: "", // Will be set from LDAP response if available
+			DN:         resolved.DN,
+			ObjectGUID: resolved.GUID,
 			ObjectSID:  "", // Will be set from LDAP response if available
 			Attributes: make(map[string][]string),
 		}
 		_ = m.cacheManager.Put(cacheEntry) // Ignore cache errors - they're not critical
 	}
 
-	return normalizedDN, nil
+	return resolved, nil
 }
 
-// NormalizeToDNBatch normalizes multiple identifiers in a single operation for better performance.
-// Returns two maps: successful normalizations (identifier -> DN) and failures (identifier -> error).
-// This allows callers to decide how to handle partial failures based on configuration.
+// ResolveBatch resolves multiple identifiers in a single operation for better performance.
+// Returns two maps: successful resolutions (identifier -> ResolvedIdentifier) and failures
+// (identifier -> error). This allows callers to decide how to handle partial failures based
+// on configuration.
 //
 // Results and failures are keyed by the caller's original identifier (whitespace
 // preserved); internal cache and LDAP lookups use the trimmed value. Identifiers
 // that are empty or whitespace-only are skipped and appear in neither map.
-func (m *MemberNormalizer) NormalizeToDNBatch(identifiers []string) (map[string]string, map[string]error) {
-	results := make(map[string]string, len(identifiers))
+func (m *MemberNormalizer) ResolveBatch(identifiers []string) (map[string]ResolvedIdentifier, map[string]error) {
+	results := make(map[string]ResolvedIdentifier, len(identifiers))
 	failures := make(map[string]error, len(identifiers))
 
 	for _, original := range identifiers {
@@ -197,29 +209,29 @@ func (m *MemberNormalizer) NormalizeToDNBatch(identifiers []string) (map[string]
 		}
 		if m.cacheManager != nil {
 			if cached, found := m.cacheManager.Get(trimmed); found {
-				results[original] = cached.DN
+				results[original] = ResolvedIdentifier{DN: cached.DN, GUID: cached.ObjectGUID}
 				continue
 			}
 		}
-		dn, err := m.NormalizeToDN(trimmed)
+		resolved, err := m.Resolve(trimmed)
 		if err != nil {
 			failures[original] = err
 		} else {
-			results[original] = dn
+			results[original] = resolved
 		}
 	}
 	return results, failures
 }
 
-// validateDN verifies that a DN exists in Active Directory.
-func (m *MemberNormalizer) validateDN(dn string) (string, error) {
+// validateDN verifies that a DN-shaped input exists in Active Directory.
+func (m *MemberNormalizer) validateDN(dn string) (ResolvedIdentifier, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), m.timeout)
 	defer cancel()
 
 	// Normalize DN case before searching to ensure consistent format
 	normalizedSearchDN, err := NormalizeDNCase(dn)
 	if err != nil {
-		return "", fmt.Errorf("failed to normalize DN case for search: %w", err)
+		return ResolvedIdentifier{}, fmt.Errorf("failed to normalize DN case for search: %w", err)
 	}
 
 	// Perform a base object search to verify the DN exists
@@ -227,145 +239,160 @@ func (m *MemberNormalizer) validateDN(dn string) (string, error) {
 		BaseDN:     normalizedSearchDN,
 		Scope:      ScopeBaseObject,
 		Filter:     "(objectClass=*)",
-		Attributes: []string{"distinguishedName"},
+		Attributes: []string{"distinguishedName", "objectGUID"},
 		SizeLimit:  1,
 		TimeLimit:  m.timeout,
 	}
 
 	result, err := m.client.Search(ctx, searchReq)
 	if err != nil {
-		return "", fmt.Errorf("DN validation failed: %w", err)
+		return ResolvedIdentifier{}, fmt.Errorf("DN validation failed: %w", err)
 	}
 
 	if len(result.Entries) == 0 {
-		return "", fmt.Errorf("DN not found: %s", normalizedSearchDN)
+		return ResolvedIdentifier{}, fmt.Errorf("DN not found: %s", normalizedSearchDN)
 	}
+
+	guid := m.guidHandler.ExtractGUIDSafe(result.Entries[0])
 
 	// Return the canonical DN from the server, normalized to uppercase attribute types
 	canonicalDN := result.Entries[0].GetAttributeValue("distinguishedName")
 	if canonicalDN == "" {
-		return normalizedSearchDN, nil // Fallback to normalized input DN if canonical not available
+		return ResolvedIdentifier{DN: normalizedSearchDN, GUID: guid}, nil // Fallback to normalized input DN if canonical not available
 	}
 
 	// Normalize the canonical DN from AD (should already be uppercase, but ensure consistency)
 	normalizedCanonicalDN, err := NormalizeDNCase(canonicalDN)
 	if err != nil {
-		return "", fmt.Errorf("failed to normalize canonical DN case: %w", err)
+		return ResolvedIdentifier{}, fmt.Errorf("failed to normalize canonical DN case: %w", err)
 	}
 
 	// Cache the validated DN result
 	if m.cacheManager != nil {
 		cacheEntry := &LDAPCacheEntry{
 			DN:         normalizedCanonicalDN,
-			Attributes: make(map[string][]string),
-		}
-		_ = m.cacheManager.Put(cacheEntry) // Ignore cache errors - they're not critical
-	}
-
-	return normalizedCanonicalDN, nil
-}
-
-// resolveGUIDToDN resolves a GUID to its Distinguished Name.
-func (m *MemberNormalizer) resolveGUIDToDN(guid string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), m.timeout)
-	defer cancel()
-
-	// Create GUID search request
-	searchReq, err := m.guidHandler.GenerateGUIDSearchRequest(m.baseDN, guid)
-	if err != nil {
-		return "", fmt.Errorf("failed to create GUID search request: %w", err)
-	}
-
-	searchReq.TimeLimit = m.timeout
-
-	result, err := m.client.Search(ctx, searchReq)
-	if err != nil {
-		return "", fmt.Errorf("GUID search failed: %w", err)
-	}
-
-	if len(result.Entries) == 0 {
-		return "", fmt.Errorf("object with GUID %s not found", guid)
-	}
-
-	dn := result.Entries[0].DN
-	if dn == "" {
-		return "", fmt.Errorf("DN not found for GUID %s", guid)
-	}
-
-	// Normalize DN case to ensure uppercase attribute types
-	normalizedDN, err := NormalizeDNCase(dn)
-	if err != nil {
-		return "", fmt.Errorf("failed to normalize DN case for GUID %s: %w", guid, err)
-	}
-
-	// Cache the result with GUID for future lookups
-	if m.cacheManager != nil {
-		cacheEntry := &LDAPCacheEntry{
-			DN:         normalizedDN,
 			ObjectGUID: guid,
 			Attributes: make(map[string][]string),
 		}
 		_ = m.cacheManager.Put(cacheEntry) // Ignore cache errors - they're not critical
 	}
 
-	return normalizedDN, nil
+	return ResolvedIdentifier{DN: normalizedCanonicalDN, GUID: guid}, nil
 }
 
-// ResolveSIDToDN resolves a Security Identifier to its Distinguished Name.
-func (m *MemberNormalizer) ResolveSIDToDN(sid string) (string, error) {
+// resolveGUID resolves a GUID to its Distinguished Name.
+func (m *MemberNormalizer) resolveGUID(guid string) (ResolvedIdentifier, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), m.timeout)
+	defer cancel()
+
+	// Create GUID search request
+	searchReq, err := m.guidHandler.GenerateGUIDSearchRequest(m.baseDN, guid)
+	if err != nil {
+		return ResolvedIdentifier{}, fmt.Errorf("failed to create GUID search request: %w", err)
+	}
+
+	searchReq.TimeLimit = m.timeout
+
+	result, err := m.client.Search(ctx, searchReq)
+	if err != nil {
+		return ResolvedIdentifier{}, fmt.Errorf("GUID search failed: %w", err)
+	}
+
+	if len(result.Entries) == 0 {
+		return ResolvedIdentifier{}, fmt.Errorf("object with GUID %s not found", guid)
+	}
+
+	dn := result.Entries[0].DN
+	if dn == "" {
+		return ResolvedIdentifier{}, fmt.Errorf("DN not found for GUID %s", guid)
+	}
+
+	// Normalize DN case to ensure uppercase attribute types
+	normalizedDN, err := NormalizeDNCase(dn)
+	if err != nil {
+		return ResolvedIdentifier{}, fmt.Errorf("failed to normalize DN case for GUID %s: %w", guid, err)
+	}
+
+	// Prefer the canonical GUID extracted from the entry itself, falling back
+	// to the (already-canonical, since it matched IdentifierTypeGUID) input.
+	resolvedGUID := m.guidHandler.ExtractGUIDSafe(result.Entries[0])
+	if resolvedGUID == "" {
+		if normalized, normErr := m.guidHandler.NormalizeGUID(guid); normErr == nil {
+			resolvedGUID = normalized
+		}
+	}
+
+	// Cache the result with GUID for future lookups
+	if m.cacheManager != nil {
+		cacheEntry := &LDAPCacheEntry{
+			DN:         normalizedDN,
+			ObjectGUID: resolvedGUID,
+			Attributes: make(map[string][]string),
+		}
+		_ = m.cacheManager.Put(cacheEntry) // Ignore cache errors - they're not critical
+	}
+
+	return ResolvedIdentifier{DN: normalizedDN, GUID: resolvedGUID}, nil
+}
+
+// ResolveSID resolves a Security Identifier to its Distinguished Name.
+func (m *MemberNormalizer) ResolveSID(sid string) (ResolvedIdentifier, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), m.timeout)
 	defer cancel()
 
 	// Search by objectSid using binary encoding
 	sidFilter, err := m.sidHandler.SIDToSearchFilter(sid)
 	if err != nil {
-		return "", fmt.Errorf("failed to create SID search filter: %w", err)
+		return ResolvedIdentifier{}, fmt.Errorf("failed to create SID search filter: %w", err)
 	}
 
 	searchReq := &SearchRequest{
 		BaseDN:     m.baseDN,
 		Scope:      ScopeWholeSubtree,
 		Filter:     sidFilter,
-		Attributes: []string{"distinguishedName"},
+		Attributes: []string{"distinguishedName", "objectGUID"},
 		SizeLimit:  1,
 		TimeLimit:  m.timeout,
 	}
 
 	result, err := m.client.Search(ctx, searchReq)
 	if err != nil {
-		return "", fmt.Errorf("SID search failed: %w", err)
+		return ResolvedIdentifier{}, fmt.Errorf("SID search failed: %w", err)
 	}
 
 	if len(result.Entries) == 0 {
-		return "", fmt.Errorf("object with SID %s not found", sid)
+		return ResolvedIdentifier{}, fmt.Errorf("object with SID %s not found", sid)
 	}
 
 	dn := result.Entries[0].DN
 	if dn == "" {
-		return "", fmt.Errorf("DN not found for SID %s", sid)
+		return ResolvedIdentifier{}, fmt.Errorf("DN not found for SID %s", sid)
 	}
 
 	// Normalize DN case to ensure uppercase attribute types
 	normalizedDN, err := NormalizeDNCase(dn)
 	if err != nil {
-		return "", fmt.Errorf("failed to normalize DN case for SID %s: %w", sid, err)
+		return ResolvedIdentifier{}, fmt.Errorf("failed to normalize DN case for SID %s: %w", sid, err)
 	}
+
+	guid := m.guidHandler.ExtractGUIDSafe(result.Entries[0])
 
 	// Cache the result with SID for future lookups
 	if m.cacheManager != nil {
 		cacheEntry := &LDAPCacheEntry{
 			DN:         normalizedDN,
+			ObjectGUID: guid,
 			ObjectSID:  sid,
 			Attributes: make(map[string][]string),
 		}
 		_ = m.cacheManager.Put(cacheEntry) // Ignore cache errors - they're not critical
 	}
 
-	return normalizedDN, nil
+	return ResolvedIdentifier{DN: normalizedDN, GUID: guid}, nil
 }
 
-// resolveUPNToDN resolves a User Principal Name to its Distinguished Name.
-func (m *MemberNormalizer) resolveUPNToDN(upn string) (string, error) {
+// resolveUPN resolves a User Principal Name to its Distinguished Name.
+func (m *MemberNormalizer) resolveUPN(upn string) (ResolvedIdentifier, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), m.timeout)
 	defer cancel()
 
@@ -374,35 +401,38 @@ func (m *MemberNormalizer) resolveUPNToDN(upn string) (string, error) {
 		BaseDN:     m.baseDN,
 		Scope:      ScopeWholeSubtree,
 		Filter:     fmt.Sprintf("(userPrincipalName=%s)", ldap.EscapeFilter(upn)),
-		Attributes: []string{"distinguishedName"},
+		Attributes: []string{"distinguishedName", "objectGUID"},
 		SizeLimit:  1,
 		TimeLimit:  m.timeout,
 	}
 
 	result, err := m.client.Search(ctx, searchReq)
 	if err != nil {
-		return "", fmt.Errorf("UPN search failed: %w", err)
+		return ResolvedIdentifier{}, fmt.Errorf("UPN search failed: %w", err)
 	}
 
 	if len(result.Entries) == 0 {
-		return "", fmt.Errorf("object with UPN %s not found", upn)
+		return ResolvedIdentifier{}, fmt.Errorf("object with UPN %s not found", upn)
 	}
 
 	dn := result.Entries[0].DN
 	if dn == "" {
-		return "", fmt.Errorf("DN not found for UPN %s", upn)
+		return ResolvedIdentifier{}, fmt.Errorf("DN not found for UPN %s", upn)
 	}
 
 	// Normalize DN case to ensure uppercase attribute types
 	normalizedDN, err := NormalizeDNCase(dn)
 	if err != nil {
-		return "", fmt.Errorf("failed to normalize DN case for UPN %s: %w", upn, err)
+		return ResolvedIdentifier{}, fmt.Errorf("failed to normalize DN case for UPN %s: %w", upn, err)
 	}
+
+	guid := m.guidHandler.ExtractGUIDSafe(result.Entries[0])
 
 	// Cache the result with UPN for future lookups
 	if m.cacheManager != nil {
 		cacheEntry := &LDAPCacheEntry{
-			DN: normalizedDN,
+			DN:         normalizedDN,
+			ObjectGUID: guid,
 			Attributes: map[string][]string{
 				"userPrincipalName": {upn},
 			},
@@ -410,11 +440,11 @@ func (m *MemberNormalizer) resolveUPNToDN(upn string) (string, error) {
 		_ = m.cacheManager.Put(cacheEntry) // Ignore cache errors - they're not critical
 	}
 
-	return normalizedDN, nil
+	return ResolvedIdentifier{DN: normalizedDN, GUID: guid}, nil
 }
 
-// resolveSAMToDN resolves a SAM Account Name to its Distinguished Name.
-func (m *MemberNormalizer) resolveSAMToDN(sam string) (string, error) {
+// resolveSAM resolves a SAM Account Name to its Distinguished Name.
+func (m *MemberNormalizer) resolveSAM(sam string) (ResolvedIdentifier, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), m.timeout)
 	defer cancel()
 
@@ -432,35 +462,38 @@ func (m *MemberNormalizer) resolveSAMToDN(sam string) (string, error) {
 		BaseDN:     m.baseDN,
 		Scope:      ScopeWholeSubtree,
 		Filter:     fmt.Sprintf("(sAMAccountName=%s)", ldap.EscapeFilter(username)),
-		Attributes: []string{"distinguishedName"},
+		Attributes: []string{"distinguishedName", "objectGUID"},
 		SizeLimit:  1,
 		TimeLimit:  m.timeout,
 	}
 
 	result, err := m.client.Search(ctx, searchReq)
 	if err != nil {
-		return "", fmt.Errorf("SAM search failed: %w", err)
+		return ResolvedIdentifier{}, fmt.Errorf("SAM search failed: %w", err)
 	}
 
 	if len(result.Entries) == 0 {
-		return "", fmt.Errorf("object with SAM %s not found", sam)
+		return ResolvedIdentifier{}, fmt.Errorf("object with SAM %s not found", sam)
 	}
 
 	dn := result.Entries[0].DN
 	if dn == "" {
-		return "", fmt.Errorf("DN not found for SAM %s", sam)
+		return ResolvedIdentifier{}, fmt.Errorf("DN not found for SAM %s", sam)
 	}
 
 	// Normalize DN case to ensure uppercase attribute types
 	normalizedDN, err := NormalizeDNCase(dn)
 	if err != nil {
-		return "", fmt.Errorf("failed to normalize DN case for SAM %s: %w", sam, err)
+		return ResolvedIdentifier{}, fmt.Errorf("failed to normalize DN case for SAM %s: %w", sam, err)
 	}
+
+	guid := m.guidHandler.ExtractGUIDSafe(result.Entries[0])
 
 	// Cache the result with SAM for future lookups
 	if m.cacheManager != nil {
 		cacheEntry := &LDAPCacheEntry{
-			DN: normalizedDN,
+			DN:         normalizedDN,
+			ObjectGUID: guid,
 			Attributes: map[string][]string{
 				"sAMAccountName": {username},
 			},
@@ -468,7 +501,7 @@ func (m *MemberNormalizer) resolveSAMToDN(sam string) (string, error) {
 		_ = m.cacheManager.Put(cacheEntry) // Ignore cache errors - they're not critical
 	}
 
-	return normalizedDN, nil
+	return ResolvedIdentifier{DN: normalizedDN, GUID: guid}, nil
 }
 
 // ValidateIdentifier checks if an identifier is valid and can be normalized.

--- a/internal/ldap/normalizer_test.go
+++ b/internal/ldap/normalizer_test.go
@@ -290,7 +290,20 @@ func TestMemberNormalizer_ValidateIdentifier(t *testing.T) {
 	}
 }
 
-func TestMemberNormalizer_NormalizeToDN_DN(t *testing.T) {
+// mustGUIDBytes converts a canonical hyphenated GUID string to AD's binary
+// mixed-endian encoding, for use as an entry's raw objectGUID attribute value.
+func mustGUIDBytes(t *testing.T, guid string) []byte {
+	t.Helper()
+	b, err := NewGUIDHandler().StringToGUIDBytes(guid)
+	require.NoError(t, err)
+	return b
+}
+
+// resolvedEntryGUID is the canonical GUID returned in objectGUID for entries
+// in the tests below, distinct from any identifier under test.
+const resolvedEntryGUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+func TestMemberNormalizer_Resolve_DN(t *testing.T) {
 	mockClient := &MockClient{}
 	normalizer := NewMemberNormalizer(mockClient, "dc=example,dc=com", nil)
 
@@ -310,19 +323,52 @@ func TestMemberNormalizer_NormalizeToDN_DN(t *testing.T) {
 						Values: []string{canonicalDN},
 					},
 				},
+				// objectGUID intentionally omitted to also cover the
+				// "GUID unavailable" fallback (empty, never an error) path.
 			},
 		},
 		Total: 1,
 	}, nil)
 
-	result, err := normalizer.NormalizeToDN(dn)
+	result, err := normalizer.Resolve(dn)
 
 	require.NoError(t, err)
-	assert.Equal(t, canonicalDN, result)
+	assert.Equal(t, canonicalDN, result.DN)
+	assert.Empty(t, result.GUID, "GUID should be empty when objectGUID is unavailable")
 	mockClient.AssertExpectations(t)
 }
 
-func TestMemberNormalizer_NormalizeToDN_GUID(t *testing.T) {
+func TestMemberNormalizer_Resolve_DN_WithGUID(t *testing.T) {
+	mockClient := &MockClient{}
+	normalizer := NewMemberNormalizer(mockClient, "dc=example,dc=com", nil)
+
+	dn := "CN=User,OU=Users,DC=example,DC=com"
+	canonicalDN := "CN=User,OU=Users,DC=example,DC=com"
+
+	mockClient.On("Search", mock.Anything, mock.MatchedBy(func(req *SearchRequest) bool {
+		return req.BaseDN == dn && req.Scope == ScopeBaseObject
+	})).Return(&SearchResult{
+		Entries: []*ldap.Entry{
+			{
+				DN: canonicalDN,
+				Attributes: []*ldap.EntryAttribute{
+					{Name: "distinguishedName", Values: []string{canonicalDN}},
+					{Name: "objectGUID", ByteValues: [][]byte{mustGUIDBytes(t, resolvedEntryGUID)}},
+				},
+			},
+		},
+		Total: 1,
+	}, nil)
+
+	result, err := normalizer.Resolve(dn)
+
+	require.NoError(t, err)
+	assert.Equal(t, canonicalDN, result.DN)
+	assert.Equal(t, resolvedEntryGUID, result.GUID)
+	mockClient.AssertExpectations(t)
+}
+
+func TestMemberNormalizer_Resolve_GUID(t *testing.T) {
 	mockClient := &MockClient{}
 	normalizer := NewMemberNormalizer(mockClient, "dc=example,dc=com", nil)
 
@@ -338,19 +384,23 @@ func TestMemberNormalizer_NormalizeToDN_GUID(t *testing.T) {
 		Entries: []*ldap.Entry{
 			{
 				DN: expectedDN,
+				Attributes: []*ldap.EntryAttribute{
+					{Name: "objectGUID", ByteValues: [][]byte{mustGUIDBytes(t, guid)}},
+				},
 			},
 		},
 		Total: 1,
 	}, nil)
 
-	result, err := normalizer.NormalizeToDN(guid)
+	result, err := normalizer.Resolve(guid)
 
 	require.NoError(t, err)
-	assert.Equal(t, expectedDN, result)
+	assert.Equal(t, expectedDN, result.DN)
+	assert.Equal(t, guid, result.GUID)
 	mockClient.AssertExpectations(t)
 }
 
-func TestMemberNormalizer_NormalizeToDN_SID(t *testing.T) {
+func TestMemberNormalizer_Resolve_SID(t *testing.T) {
 	mockClient := &MockClient{}
 	normalizer := NewMemberNormalizer(mockClient, "dc=example,dc=com", nil)
 
@@ -367,19 +417,23 @@ func TestMemberNormalizer_NormalizeToDN_SID(t *testing.T) {
 		Entries: []*ldap.Entry{
 			{
 				DN: expectedDN,
+				Attributes: []*ldap.EntryAttribute{
+					{Name: "objectGUID", ByteValues: [][]byte{mustGUIDBytes(t, resolvedEntryGUID)}},
+				},
 			},
 		},
 		Total: 1,
 	}, nil)
 
-	result, err := normalizer.NormalizeToDN(sid)
+	result, err := normalizer.Resolve(sid)
 
 	require.NoError(t, err)
-	assert.Equal(t, expectedDN, result)
+	assert.Equal(t, expectedDN, result.DN)
+	assert.Equal(t, resolvedEntryGUID, result.GUID)
 	mockClient.AssertExpectations(t)
 }
 
-func TestMemberNormalizer_NormalizeToDN_UPN(t *testing.T) {
+func TestMemberNormalizer_Resolve_UPN(t *testing.T) {
 	mockClient := &MockClient{}
 	normalizer := NewMemberNormalizer(mockClient, "dc=example,dc=com", nil)
 
@@ -394,19 +448,23 @@ func TestMemberNormalizer_NormalizeToDN_UPN(t *testing.T) {
 		Entries: []*ldap.Entry{
 			{
 				DN: expectedDN,
+				Attributes: []*ldap.EntryAttribute{
+					{Name: "objectGUID", ByteValues: [][]byte{mustGUIDBytes(t, resolvedEntryGUID)}},
+				},
 			},
 		},
 		Total: 1,
 	}, nil)
 
-	result, err := normalizer.NormalizeToDN(upn)
+	result, err := normalizer.Resolve(upn)
 
 	require.NoError(t, err)
-	assert.Equal(t, expectedDN, result)
+	assert.Equal(t, expectedDN, result.DN)
+	assert.Equal(t, resolvedEntryGUID, result.GUID)
 	mockClient.AssertExpectations(t)
 }
 
-func TestMemberNormalizer_NormalizeToDN_SAM(t *testing.T) {
+func TestMemberNormalizer_Resolve_SAM(t *testing.T) {
 	mockClient := &MockClient{}
 	normalizer := NewMemberNormalizer(mockClient, "dc=example,dc=com", nil)
 
@@ -439,22 +497,51 @@ func TestMemberNormalizer_NormalizeToDN_SAM(t *testing.T) {
 				Entries: []*ldap.Entry{
 					{
 						DN: expectedDN,
+						Attributes: []*ldap.EntryAttribute{
+							{Name: "objectGUID", ByteValues: [][]byte{mustGUIDBytes(t, resolvedEntryGUID)}},
+						},
 					},
 				},
 				Total: 1,
 			}, nil).Once()
 
-			result, err := normalizer.NormalizeToDN(tt.sam)
+			result, err := normalizer.Resolve(tt.sam)
 
 			require.NoError(t, err)
-			assert.Equal(t, expectedDN, result)
+			assert.Equal(t, expectedDN, result.DN)
+			assert.Equal(t, resolvedEntryGUID, result.GUID)
 		})
 	}
 
 	mockClient.AssertExpectations(t)
 }
 
-func TestMemberNormalizer_NormalizeToDN_NotFound(t *testing.T) {
+func TestMemberNormalizer_Resolve_CacheHit_HasGUID(t *testing.T) {
+	mockClient := &MockClient{}
+	cacheManager := NewCacheManager()
+	normalizer := NewMemberNormalizer(mockClient, "dc=example,dc=com", cacheManager)
+
+	upn := "cached@example.com"
+	cachedDN := "CN=Cached User,OU=Users,DC=example,DC=com"
+
+	require.NoError(t, cacheManager.Put(&LDAPCacheEntry{
+		DN:         cachedDN,
+		ObjectGUID: resolvedEntryGUID,
+		Attributes: map[string][]string{
+			"userPrincipalName": {upn},
+		},
+	}))
+
+	result, err := normalizer.Resolve(upn)
+
+	require.NoError(t, err)
+	assert.Equal(t, cachedDN, result.DN)
+	assert.Equal(t, resolvedEntryGUID, result.GUID)
+	// A cache hit must not issue any LDAP search.
+	mockClient.AssertNotCalled(t, "Search", mock.Anything, mock.Anything)
+}
+
+func TestMemberNormalizer_Resolve_NotFound(t *testing.T) {
 	mockClient := &MockClient{}
 	normalizer := NewMemberNormalizer(mockClient, "dc=example,dc=com", nil)
 
@@ -468,15 +555,16 @@ func TestMemberNormalizer_NormalizeToDN_NotFound(t *testing.T) {
 		Total:   0,
 	}, nil)
 
-	result, err := normalizer.NormalizeToDN(guid)
+	result, err := normalizer.Resolve(guid)
 
 	assert.Error(t, err)
-	assert.Empty(t, result)
+	assert.Empty(t, result.DN)
+	assert.Empty(t, result.GUID)
 	assert.Contains(t, err.Error(), "not found")
 	mockClient.AssertExpectations(t)
 }
 
-func TestMemberNormalizer_NormalizeToDNBatch(t *testing.T) {
+func TestMemberNormalizer_ResolveBatch(t *testing.T) {
 	mockClient := &MockClient{}
 	normalizer := NewMemberNormalizer(mockClient, "dc=example,dc=com", nil)
 
@@ -486,7 +574,7 @@ func TestMemberNormalizer_NormalizeToDNBatch(t *testing.T) {
 		"user2@example.com",
 	}
 
-	expectedResults := map[string]string{
+	expectedDNs := map[string]string{
 		"CN=User1,OU=Users,DC=example,DC=com":  "CN=User1,OU=Users,DC=example,DC=com",
 		"12345678-1234-1234-1234-123456789012": "CN=User2,OU=Users,DC=example,DC=com",
 		"user2@example.com":                    "CN=User2,OU=Users,DC=example,DC=com",
@@ -504,8 +592,13 @@ func TestMemberNormalizer_NormalizeToDNBatch(t *testing.T) {
 	mockClient.On("Search", mock.Anything, mock.MatchedBy(func(req *SearchRequest) bool {
 		return req.BaseDN == "dc=example,dc=com" && req.SizeLimit == 1
 	})).Return(&SearchResult{
-		Entries: []*ldap.Entry{{DN: "CN=User2,OU=Users,DC=example,DC=com"}},
-		Total:   1,
+		Entries: []*ldap.Entry{{
+			DN: "CN=User2,OU=Users,DC=example,DC=com",
+			Attributes: []*ldap.EntryAttribute{
+				{Name: "objectGUID", ByteValues: [][]byte{mustGUIDBytes(t, "12345678-1234-1234-1234-123456789012")}},
+			},
+		}},
+		Total: 1,
 	}, nil)
 
 	// Mock UPN search
@@ -517,14 +610,20 @@ func TestMemberNormalizer_NormalizeToDNBatch(t *testing.T) {
 		Total:   1,
 	}, nil)
 
-	results, failures := normalizer.NormalizeToDNBatch(identifiers)
+	results, failures := normalizer.ResolveBatch(identifiers)
 
 	assert.Empty(t, failures, "expected no failures")
-	assert.Equal(t, expectedResults, results)
+	require.Len(t, results, len(expectedDNs))
+	for identifier, expectedDN := range expectedDNs {
+		require.Contains(t, results, identifier)
+		assert.Equal(t, expectedDN, results[identifier].DN, "DN for %s", identifier)
+	}
+	// The GUID identifier's own value must round-trip into the resolved GUID.
+	assert.Equal(t, "12345678-1234-1234-1234-123456789012", results["12345678-1234-1234-1234-123456789012"].GUID)
 	mockClient.AssertExpectations(t)
 }
 
-func TestMemberNormalizer_NormalizeToDNBatch_PartialFailures(t *testing.T) {
+func TestMemberNormalizer_ResolveBatch_PartialFailures(t *testing.T) {
 	mockClient := &MockClient{}
 	normalizer := NewMemberNormalizer(mockClient, "dc=example,dc=com", nil)
 
@@ -566,12 +665,12 @@ func TestMemberNormalizer_NormalizeToDNBatch_PartialFailures(t *testing.T) {
 		Total:   0,
 	}, nil)
 
-	results, failures := normalizer.NormalizeToDNBatch(identifiers)
+	results, failures := normalizer.ResolveBatch(identifiers)
 
 	// Should have 2 successful results
 	assert.Len(t, results, 2)
-	assert.Equal(t, "CN=User1,OU=Users,DC=example,DC=com", results["CN=User1,OU=Users,DC=example,DC=com"])
-	assert.Equal(t, "CN=User2,OU=Users,DC=example,DC=com", results["CN=User2,OU=Users,DC=example,DC=com"])
+	assert.Equal(t, "CN=User1,OU=Users,DC=example,DC=com", results["CN=User1,OU=Users,DC=example,DC=com"].DN)
+	assert.Equal(t, "CN=User2,OU=Users,DC=example,DC=com", results["CN=User2,OU=Users,DC=example,DC=com"].DN)
 
 	// Should have 1 failure
 	assert.Len(t, failures, 1)
@@ -579,7 +678,7 @@ func TestMemberNormalizer_NormalizeToDNBatch_PartialFailures(t *testing.T) {
 	assert.Contains(t, failures["nonexistent@example.com"].Error(), "nonexistent@example.com")
 }
 
-func TestMemberNormalizer_NormalizeToDNBatch_AllFail(t *testing.T) {
+func TestMemberNormalizer_ResolveBatch_AllFail(t *testing.T) {
 	mockClient := &MockClient{}
 	normalizer := NewMemberNormalizer(mockClient, "dc=example,dc=com", nil)
 
@@ -618,7 +717,7 @@ func TestMemberNormalizer_NormalizeToDNBatch_AllFail(t *testing.T) {
 		Total:   0,
 	}, nil)
 
-	results, failures := normalizer.NormalizeToDNBatch(identifiers)
+	results, failures := normalizer.ResolveBatch(identifiers)
 
 	// Should have no successful results
 	assert.Empty(t, results, "expected no successful normalizations")
@@ -629,11 +728,11 @@ func TestMemberNormalizer_NormalizeToDNBatch_AllFail(t *testing.T) {
 	assert.Contains(t, failures, "bad2@example.com")
 }
 
-// TestMemberNormalizer_NormalizeToDNBatch_WhitespacePreservation asserts the
+// TestMemberNormalizer_ResolveBatch_WhitespacePreservation asserts the
 // external contract: result and failure maps are keyed by the caller's
 // original identifier (whitespace preserved), while internal cache and LDAP
 // lookups use the trimmed value. Empty/whitespace-only entries are skipped.
-func TestMemberNormalizer_NormalizeToDNBatch_WhitespacePreservation(t *testing.T) {
+func TestMemberNormalizer_ResolveBatch_WhitespacePreservation(t *testing.T) {
 	t.Run("padded_DN_success", func(t *testing.T) {
 		mockClient := &MockClient{}
 		normalizer := NewMemberNormalizer(mockClient, "dc=example,dc=com", nil)
@@ -654,12 +753,12 @@ func TestMemberNormalizer_NormalizeToDNBatch_WhitespacePreservation(t *testing.T
 			Total: 1,
 		}, nil).Once()
 
-		results, failures := normalizer.NormalizeToDNBatch([]string{paddedDN})
+		results, failures := normalizer.ResolveBatch([]string{paddedDN})
 
 		assert.Empty(t, failures, "expected no failures")
 		assert.Contains(t, results, paddedDN)
 		assert.NotContains(t, results, canonicalDN)
-		assert.Equal(t, canonicalDN, results[paddedDN])
+		assert.Equal(t, canonicalDN, results[paddedDN].DN)
 		mockClient.AssertExpectations(t)
 	})
 
@@ -680,12 +779,12 @@ func TestMemberNormalizer_NormalizeToDNBatch_WhitespacePreservation(t *testing.T
 			Total:   1,
 		}, nil).Once()
 
-		results, failures := normalizer.NormalizeToDNBatch([]string{paddedUPN})
+		results, failures := normalizer.ResolveBatch([]string{paddedUPN})
 
 		assert.Empty(t, failures, "expected no failures")
 		assert.Contains(t, results, paddedUPN)
 		assert.NotContains(t, results, trimmedUPN)
-		assert.Equal(t, canonicalDN, results[paddedUPN])
+		assert.Equal(t, canonicalDN, results[paddedUPN].DN)
 		mockClient.AssertExpectations(t)
 	})
 
@@ -706,7 +805,7 @@ func TestMemberNormalizer_NormalizeToDNBatch_WhitespacePreservation(t *testing.T
 			Total:   0,
 		}, nil).Once()
 
-		results, failures := normalizer.NormalizeToDNBatch([]string{paddedBad})
+		results, failures := normalizer.ResolveBatch([]string{paddedBad})
 
 		assert.Empty(t, results, "expected no successful normalizations")
 		assert.Contains(t, failures, paddedBad)
@@ -729,7 +828,8 @@ func TestMemberNormalizer_NormalizeToDNBatch_WhitespacePreservation(t *testing.T
 
 		// Pre-populate the cache so a Get on the trimmed value succeeds.
 		require.NoError(t, cacheManager.Put(&LDAPCacheEntry{
-			DN: canonicalDN,
+			DN:         canonicalDN,
+			ObjectGUID: resolvedEntryGUID,
 			Attributes: map[string][]string{
 				"userPrincipalName": {trimmedUPN},
 			},
@@ -740,12 +840,13 @@ func TestMemberNormalizer_NormalizeToDNBatch_WhitespacePreservation(t *testing.T
 		require.True(t, found, "cache must serve the trimmed UPN lookup")
 		require.Equal(t, canonicalDN, cached.DN)
 
-		results, failures := normalizer.NormalizeToDNBatch([]string{paddedUPN})
+		results, failures := normalizer.ResolveBatch([]string{paddedUPN})
 
 		assert.Empty(t, failures, "expected no failures")
 		assert.Contains(t, results, paddedUPN)
 		assert.NotContains(t, results, trimmedUPN)
-		assert.Equal(t, canonicalDN, results[paddedUPN])
+		assert.Equal(t, canonicalDN, results[paddedUPN].DN)
+		assert.Equal(t, resolvedEntryGUID, results[paddedUPN].GUID, "cache hit must carry the cached GUID for free")
 		// Verify no LDAP search was issued (cache served the request).
 		mockClient.AssertNotCalled(t, "Search", mock.Anything, mock.Anything)
 	})
@@ -756,7 +857,7 @@ func TestMemberNormalizer_NormalizeToDNBatch_WhitespacePreservation(t *testing.T
 
 		identifiers := []string{"", "   ", "\t\n"}
 
-		results, failures := normalizer.NormalizeToDNBatch(identifiers)
+		results, failures := normalizer.ResolveBatch(identifiers)
 
 		assert.Empty(t, results, "skipped entries must not appear in results")
 		assert.Empty(t, failures, "skipped entries must not appear in failures")
@@ -807,12 +908,12 @@ func TestMemberNormalizer_NormalizeToDNBatch_WhitespacePreservation(t *testing.T
 			Total:   0,
 		}, nil).Once()
 
-		results, failures := normalizer.NormalizeToDNBatch(members)
+		results, failures := normalizer.ResolveBatch(members)
 
 		var found, missing []string
 		for _, member := range members {
-			if dn, ok := results[member]; ok {
-				found = append(found, dn)
+			if resolved, ok := results[member]; ok {
+				found = append(found, resolved.DN)
 				continue
 			}
 			if _, ok := failures[member]; ok {
@@ -889,11 +990,12 @@ func TestMemberNormalizer_ErrorHandling(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := normalizer.NormalizeToDN(tt.identifier)
+			result, err := normalizer.Resolve(tt.identifier)
 
 			if tt.wantErr {
 				assert.Error(t, err)
-				assert.Empty(t, result)
+				assert.Empty(t, result.DN)
+				assert.Empty(t, result.GUID)
 				assert.Contains(t, err.Error(), tt.errMsg)
 			} else {
 				assert.NoError(t, err)
@@ -932,10 +1034,11 @@ func TestMemberNormalizer_SearchErrors(t *testing.T) {
 	mockClient.On("Search", mock.Anything, mock.AnythingOfType("*ldap.SearchRequest")).
 		Return((*SearchResult)(nil), fmt.Errorf("connection failed"))
 
-	result, err := normalizer.NormalizeToDN(guid)
+	result, err := normalizer.Resolve(guid)
 
 	assert.Error(t, err)
-	assert.Empty(t, result)
+	assert.Empty(t, result.DN)
+	assert.Empty(t, result.GUID)
 	assert.Contains(t, err.Error(), "failed to normalize identifier")
 	mockClient.AssertExpectations(t)
 }
@@ -989,7 +1092,7 @@ func TestMemberNormalizer_IntegrationScenarios(t *testing.T) {
 		Total:   1,
 	}, nil)
 
-	results, failures := normalizer.NormalizeToDNBatch(identifiers)
+	results, failures := normalizer.ResolveBatch(identifiers)
 
 	assert.Empty(t, failures, "expected no failures")
 	assert.Len(t, results, 5)
@@ -997,7 +1100,7 @@ func TestMemberNormalizer_IntegrationScenarios(t *testing.T) {
 	// Verify all identifiers were resolved
 	for _, identifier := range identifiers {
 		assert.Contains(t, results, identifier)
-		assert.NotEmpty(t, results[identifier])
+		assert.NotEmpty(t, results[identifier].DN)
 	}
 
 	mockClient.AssertExpectations(t)

--- a/internal/ldap/user.go
+++ b/internal/ldap/user.go
@@ -1151,8 +1151,8 @@ func (um *UserManager) entryToUser(entry *ldap.Entry) (*User, error) {
 			if len(sidParts) >= 4 {
 				domainSID := strings.Join(sidParts[:len(sidParts)-1], "-")
 				primaryGroupSID := fmt.Sprintf("%s-%d", domainSID, pgid)
-				if dn, err := um.normalizer.ResolveSIDToDN(primaryGroupSID); err == nil {
-					user.PrimaryGroup = dn
+				if resolved, err := um.normalizer.ResolveSID(primaryGroupSID); err == nil {
+					user.PrimaryGroup = resolved.DN
 				} else {
 					tflog.SubsystemWarn(um.ctx, "ldap", "Could not resolve primary group SID to DN, using SID", map[string]any{
 						"sid":   primaryGroupSID,
@@ -1349,11 +1349,11 @@ func (um *UserManager) buildLDAPFilter(filter *UserSearchFilter) (string, error)
 	}
 	if filter.Manager != "" {
 		// Normalize manager identifier to DN
-		managerDN, err := um.normalizer.NormalizeToDN(filter.Manager)
+		resolvedManager, err := um.normalizer.Resolve(filter.Manager)
 		if err != nil {
 			return "", fmt.Errorf("failed to normalize manager identifier: %w", err)
 		}
-		filterParts = append(filterParts, fmt.Sprintf("(manager=%s)", ldap.EscapeFilter(managerDN)))
+		filterParts = append(filterParts, fmt.Sprintf("(manager=%s)", ldap.EscapeFilter(resolvedManager.DN)))
 	}
 	if filter.Company != "" {
 		companyFilter := fmt.Sprintf("(company=%s)", ldap.EscapeFilter(filter.Company))

--- a/internal/ldap/user_test.go
+++ b/internal/ldap/user_test.go
@@ -137,7 +137,7 @@ var testBinaryGUID = []byte{0x78, 0x56, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x12
 // mockPrimaryGroupSIDResolution sets up a mock expectation for the SID-to-DN resolution
 // that entryToUser performs when processing the primaryGroupID attribute. Tests that use
 // createMockUserEntry (which includes primaryGroupID and objectSid) must call this to
-// avoid unexpected Search calls from ResolveSIDToDN.
+// avoid unexpected Search calls from ResolveSID.
 //
 // The matcher excludes filters containing "objectClass" to avoid matching the primary
 // user/group search expectations that also contain objectSid.
@@ -1002,7 +1002,7 @@ func TestUserManager_entryToUser_ComprehensiveMapping(t *testing.T) {
 	manager := NewUserManager(t.Context(), client, "DC=example,DC=com", nil)
 
 	// Mock the SID resolution search for the primary group.
-	// ResolveSIDToDN searches for objectSid matching the primary group SID.
+	// ResolveSID searches for objectSid matching the primary group SID.
 	client.On("Search", mock.Anything, mock.MatchedBy(func(req *SearchRequest) bool {
 		return req.BaseDN == "DC=example,DC=com" &&
 			req.Scope == ScopeWholeSubtree &&

--- a/internal/provider/benchmark_test.go
+++ b/internal/provider/benchmark_test.go
@@ -91,7 +91,7 @@ func BenchmarkGroupMembership(b *testing.B) {
 	// Add members to first test group
 	mainGroupID := testGroups[0]
 	membershipManager := ldapclient.NewGroupMembershipManager(ctx, helper.client, helper.config.BaseDN, ldapclient.NewCacheManager())
-	err = membershipManager.SetGroupMembers(mainGroupID, memberDNs)
+	err = membershipManager.SetGroupMembers(mainGroupID, memberDNs, nil)
 	if err != nil {
 		b.Fatalf("Failed to set members: %v", err)
 	}
@@ -113,7 +113,7 @@ func BenchmarkGroupMembership(b *testing.B) {
 
 		for i := 0; b.Loop(); i++ {
 			// Add member
-			err := membershipManager.AddGroupMembers(targetGroupID, []string{memberDN})
+			err := membershipManager.AddGroupMembers(targetGroupID, []string{memberDN}, nil)
 			if err != nil {
 				b.Logf("AddMember may have failed (expected for duplicate adds): %v", err)
 			}
@@ -272,7 +272,7 @@ func BenchmarkNormalizer(b *testing.B) {
 	// Test normalization of different identifier types
 	b.Run("NormalizeGUID", func(b *testing.B) {
 		for b.Loop() {
-			_, err := normalizer.NormalizeToDN(group.ObjectGUID)
+			_, err := normalizer.Resolve(group.ObjectGUID)
 			if err != nil {
 				b.Fatalf("GUID normalization failed: %v", err)
 			}
@@ -281,7 +281,7 @@ func BenchmarkNormalizer(b *testing.B) {
 
 	b.Run("NormalizeDN", func(b *testing.B) {
 		for b.Loop() {
-			_, err := normalizer.NormalizeToDN(group.DistinguishedName)
+			_, err := normalizer.Resolve(group.DistinguishedName)
 			if err != nil {
 				b.Fatalf("DN normalization failed: %v", err)
 			}
@@ -291,7 +291,7 @@ func BenchmarkNormalizer(b *testing.B) {
 	b.Run("NormalizeSAM", func(b *testing.B) {
 		samName := helper.config.Domain + "\\" + group.SAMAccountName
 		for b.Loop() {
-			_, err := normalizer.NormalizeToDN(samName)
+			_, err := normalizer.Resolve(samName)
 			if err != nil {
 				b.Fatalf("SAM normalization failed: %v", err)
 			}

--- a/internal/provider/resource_group.go
+++ b/internal/provider/resource_group.go
@@ -540,7 +540,7 @@ func (r *GroupResource) ImportState(ctx context.Context, req resource.ImportStat
 
 	// Normalize the import ID to a DN (supports DN, GUID, SID, UPN, SAM formats)
 	normalizer := ldapclient.NewMemberNormalizer(r.client, baseDN, r.cacheManager)
-	groupDN, err := normalizer.NormalizeToDN(importID)
+	resolved, err := normalizer.Resolve(importID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Resolving Group Identifier",
@@ -548,6 +548,7 @@ func (r *GroupResource) ImportState(ctx context.Context, req resource.ImportStat
 		)
 		return
 	}
+	groupDN := resolved.DN
 
 	tflog.Debug(ctx, "Resolved group identifier to DN", map[string]any{
 		"import_id": importID,

--- a/internal/provider/resource_group_membership.go
+++ b/internal/provider/resource_group_membership.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -40,9 +41,32 @@ type GroupMembershipResourceModel struct {
 	ID                   types.String `tfsdk:"id"`                     // Group objectGUID (same as group_id)
 	GroupID              types.String `tfsdk:"group_id"`               // Group objectGUID (required)
 	Members              types.Set    `tfsdk:"members"`                // Set of member identifiers (required, user-provided)
-	MembersNormalized    types.Set    `tfsdk:"members_normalized"`     // Set of normalized DNs (computed)
+	MemberDetails        types.Set    `tfsdk:"member_details"`         // Set of MemberDetailModel: resolved (dn, guid) pairs (computed)
 	IgnoreMissingMembers types.Bool   `tfsdk:"ignore_missing_members"` // Per-resource override for ignore_missing_members (optional)
 }
+
+// MemberDetailModel describes a single resolved member — one element of
+// MemberDetails. DN and GUID are correlated together (unlike two independent
+// flat Sets, which would lose that correlation): both are derived from the
+// same identifier, in the same ModifyPlan resolution pass, from whatever
+// format was used in `members`. GUID is the empty string when unavailable
+// (mirrors ldapclient.ResolvedIdentifier; never an error on its own).
+type MemberDetailModel struct {
+	DN   types.String `tfsdk:"dn"`
+	GUID types.String `tfsdk:"guid"`
+}
+
+// memberDetailAttrTypes/memberDetailObjectType describe the element type of
+// the `member_details` SetNestedAttribute, used whenever code needs to
+// construct or type-check a types.Set of MemberDetailModel outside of the
+// schema.Schema definition itself (ModifyPlan, Create/Update, Read,
+// ImportState).
+var memberDetailAttrTypes = map[string]attr.Type{
+	"dn":   types.StringType,
+	"guid": types.StringType,
+}
+
+var memberDetailObjectType = types.ObjectType{AttrTypes: memberDetailAttrTypes}
 
 func (r *GroupMembershipResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_group_membership"
@@ -51,8 +75,9 @@ func (r *GroupMembershipResource) Metadata(ctx context.Context, req resource.Met
 func (r *GroupMembershipResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages the membership of an Active Directory group. This resource allows you to define the complete set of members for a group, with automatic anti-drift protection through identifier normalization.\n\n" +
-			"**Anti-Drift Protection**: This resource automatically normalizes all member identifiers to distinguished names (DNs) internally while preserving your original configuration. " +
-			"The `members` attribute retains exactly what you configure, while `members_normalized` shows the DNs used for Active Directory operations.\n\n" +
+			"**Anti-Drift Protection**: This resource automatically normalizes all member identifiers to distinguished names (DNs) and object GUIDs internally while preserving your original configuration. " +
+			"The `members` attribute retains exactly what you configure, while `member_details` shows the resolved `(dn, guid)` pairs used for Active Directory operations. " +
+			"Resolution happens once, at plan time; because an object's `objectGUID` never changes for its lifetime (unlike its DN, which changes on rename), that plan-time snapshot is trusted for the rest of the apply.\n\n" +
 			"**Supported Identifier Formats**:\n" +
 			"- Distinguished Name (DN): `CN=John Doe,OU=Users,DC=example,DC=com`\n" +
 			"- Object GUID: `550e8400-e29b-41d4-a716-446655440000`\n" +
@@ -83,12 +108,19 @@ func (r *GroupMembershipResource) Schema(ctx context.Context, req resource.Schem
 				Required:    true,
 				ElementType: types.StringType,
 			},
-			"members_normalized": schema.SetAttribute{
-				MarkdownDescription: "The normalized distinguished names (DNs) of all group members. " +
-					"This computed attribute shows the actual DNs used for Active Directory operations, " +
-					"derived from the identifiers specified in the `members` attribute.",
-				Computed:    true,
-				ElementType: types.StringType,
+			"member_details": schema.SetNestedAttribute{
+				MarkdownDescription: "The resolved identity of every group member: its distinguished name " +
+					"(DN) and object GUID, both derived from whatever identifier format was used in `members`. " +
+					"This is the authoritative source used for all Active Directory operations — resolved " +
+					"once, at plan time, and immune to the member being renamed afterward (the GUID never " +
+					"changes even when the DN does).",
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"dn":   schema.StringAttribute{Computed: true, MarkdownDescription: "The member's distinguished name."},
+						"guid": schema.StringAttribute{Computed: true, MarkdownDescription: "The member's objectGUID (canonical hyphenated form)."},
+					},
+				},
 			},
 			"ignore_missing_members": schema.BoolAttribute{
 				MarkdownDescription: "When `true`, member identifiers that cannot be resolved " +
@@ -123,8 +155,13 @@ func (r *GroupMembershipResource) Configure(ctx context.Context, req resource.Co
 	r.ignoreMissingMembers = providerData.IgnoreMissingMembers
 }
 
-// ModifyPlan implements resource.ResourceWithModifyPlan to normalize members
-// during the planning phase, populating members_normalized for use in CRUD operations.
+// ModifyPlan implements resource.ResourceWithModifyPlan to resolve members
+// during the planning phase, populating member_details for use in CRUD
+// operations. Every branch below sets the WHOLE `member_details` Set to
+// Unknown/Null/empty (never a Set containing individual unknown elements) —
+// Create/Update's apply-time fallback (see extractMemberDetailsForWrite and
+// resolveMembersForWriteFallback) relies on this invariant, checking only
+// data.MemberDetails.IsUnknown()/IsNull() as a whole.
 func (r *GroupMembershipResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	// Only process if we have a plan (not during destroy)
 	if req.Plan.Raw.IsNull() {
@@ -139,33 +176,33 @@ func (r *GroupMembershipResource) ModifyPlan(ctx context.Context, req resource.M
 
 	// Handle unknown group_id (when resource depends on group being created)
 	if plan.GroupID.IsUnknown() {
-		tflog.Debug(ctx, "Group ID is unknown during planning, cannot normalize members yet")
-		// When group_id is unknown, we can't normalize members
-		// Set members_normalized to unknown as well
-		plan.MembersNormalized = types.SetUnknown(types.StringType)
+		tflog.Debug(ctx, "Group ID is unknown during planning, cannot resolve members yet")
+		// When group_id is unknown, we can't resolve members
+		// Set member_details to unknown as well
+		plan.MemberDetails = types.SetUnknown(memberDetailObjectType)
 		resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
 		return
 	}
 
-	// Always re-normalize members_normalized based on the current members in the plan
-	// This ensures that when members change, members_normalized is updated accordingly
+	// Always re-resolve member_details based on the current members in the plan
+	// This ensures that when members change, member_details is updated accordingly
 
 	// Handle unknown members (dependencies on resources not yet created during planning)
 	if plan.Members.IsUnknown() {
-		tflog.Debug(ctx, "Members is unknown during planning, setting normalized members to unknown", map[string]any{
+		tflog.Debug(ctx, "Members is unknown during planning, setting member details to unknown", map[string]any{
 			"group_id": plan.GroupID.ValueString(),
 		})
-		plan.MembersNormalized = types.SetUnknown(types.StringType)
+		plan.MemberDetails = types.SetUnknown(memberDetailObjectType)
 		resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
 		return
 	}
 
 	// Handle null members
 	if plan.Members.IsNull() {
-		tflog.Debug(ctx, "Members is null during planning, setting normalized members to null", map[string]any{
+		tflog.Debug(ctx, "Members is null during planning, setting member details to null", map[string]any{
 			"group_id": plan.GroupID.ValueString(),
 		})
-		plan.MembersNormalized = types.SetNull(types.StringType)
+		plan.MemberDetails = types.SetNull(memberDetailObjectType)
 		resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
 		return
 	}
@@ -177,16 +214,16 @@ func (r *GroupMembershipResource) ModifyPlan(ctx context.Context, req resource.M
 	if diags.HasError() {
 		// Extraction failed, likely due to unknown elements within the set
 		// This can happen when individual member identifiers depend on resources being created
-		tflog.Debug(ctx, "Failed to extract members during planning (likely unknown elements), setting normalized members to unknown", map[string]any{
+		tflog.Debug(ctx, "Failed to extract members during planning (likely unknown elements), setting member details to unknown", map[string]any{
 			"group_id": plan.GroupID.ValueString(),
 			"errors":   diags.Errors(),
 		})
-		plan.MembersNormalized = types.SetUnknown(types.StringType)
+		plan.MemberDetails = types.SetUnknown(memberDetailObjectType)
 		resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
 		return
 	}
 
-	tflog.Debug(ctx, "Normalizing member identifiers during planning", map[string]any{
+	tflog.Debug(ctx, "Resolving member identifiers during planning", map[string]any{
 		"group_id":     plan.GroupID.ValueString(),
 		"member_count": len(members),
 		"members":      members,
@@ -194,7 +231,7 @@ func (r *GroupMembershipResource) ModifyPlan(ctx context.Context, req resource.M
 
 	// Handle empty members list
 	if len(members) == 0 {
-		plan.MembersNormalized = types.SetValueMust(types.StringType, []attr.Value{})
+		plan.MemberDetails = types.SetValueMust(memberDetailObjectType, []attr.Value{})
 		resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
 		return
 	}
@@ -212,25 +249,98 @@ func (r *GroupMembershipResource) ModifyPlan(ctx context.Context, req resource.M
 	// Create normalizer
 	normalizer := ldapclient.NewMemberNormalizer(r.client, baseDN, r.cacheManager)
 
-	// Normalize all identifiers to DNs
-	normalizedMap, failures := normalizer.NormalizeToDNBatch(members)
-
 	// Resolve effective ignore_missing_members value
 	// Priority: resource explicit > provider setting
-	var effectiveIgnoreMissing bool
-	if !plan.IgnoreMissingMembers.IsNull() && !plan.IgnoreMissingMembers.IsUnknown() {
-		effectiveIgnoreMissing = plan.IgnoreMissingMembers.ValueBool()
-		tflog.Debug(ctx, "Using resource-level ignore_missing_members", map[string]any{
-			"value": effectiveIgnoreMissing,
-		})
-	} else {
-		effectiveIgnoreMissing = r.ignoreMissingMembers
-		tflog.Debug(ctx, "Using provider-level ignore_missing_members", map[string]any{
-			"value": effectiveIgnoreMissing,
-		})
+	effectiveIgnoreMissing := r.effectiveIgnoreMissingMembers(ctx, plan.IgnoreMissingMembers)
+
+	// Normalize all identifiers to DNs, applying ignore-missing semantics.
+	resolvedMap, diags := r.resolveMembers(ctx, normalizer, members, effectiveIgnoreMissing)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	// Handle any normalization failures
+	// Build the resolved (dn, guid) pairs in the same order as input (only
+	// for successfully resolved members). Both DN and GUID come from the
+	// SAME ResolvedIdentifier, so they are correlated by construction.
+	memberDetails := make([]MemberDetailModel, 0, len(resolvedMap))
+	for _, member := range members {
+		if resolved, ok := resolvedMap[member]; ok {
+			memberDetails = append(memberDetails, MemberDetailModel{
+				DN:   types.StringValue(resolved.DN),
+				GUID: types.StringValue(resolved.GUID),
+			})
+		}
+		// Skip members that failed normalization (already reported above)
+	}
+
+	// Create the member details set and update the plan
+	memberDetailsSet, diags := types.SetValueFrom(ctx, memberDetailObjectType, memberDetails)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.MemberDetails = memberDetailsSet
+
+	tflog.Debug(ctx, "Resolved member identifiers during planning", map[string]any{
+		"group_id":       plan.GroupID.ValueString(),
+		"members":        members,
+		"member_details": memberDetails,
+	})
+
+	// Save the updated plan
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+}
+
+// effectiveIgnoreMissingMembers resolves the effective ignore_missing_members
+// value from resource-level override > provider-level default precedence.
+// Used identically by ModifyPlan (reading plan.IgnoreMissingMembers) and by
+// Create/Update's fallback path, resolveMembersForWriteFallback (reading
+// data.IgnoreMissingMembers) — same field, same precedence, just sourced
+// from different model variables.
+func (r *GroupMembershipResource) effectiveIgnoreMissingMembers(ctx context.Context, resourceValue types.Bool) bool {
+	if !resourceValue.IsNull() && !resourceValue.IsUnknown() {
+		value := resourceValue.ValueBool()
+		tflog.Debug(ctx, "Using resource-level ignore_missing_members", map[string]any{
+			"value": value,
+		})
+		return value
+	}
+
+	tflog.Debug(ctx, "Using provider-level ignore_missing_members", map[string]any{
+		"value": r.ignoreMissingMembers,
+	})
+	return r.ignoreMissingMembers
+}
+
+// resolveMembers resolves verbatim member identifiers to their DN+GUID pairs
+// at the current moment (live/cached), applying ignore-missing semantics.
+// Used by ModifyPlan (plan time, populating member_details — the common
+// case, trusted through apply since objectGUID never changes) and by
+// resolveMembersForWriteFallback on behalf of Create/Update (apply time,
+// immediately before the AD write — the exception path, used only when
+// member_details is unknown/null because ModifyPlan itself could not
+// resolve members, e.g. a member being created in the very same apply).
+//
+// Returns the map of successfully resolved identifiers, keyed by the
+// caller's original, verbatim identifier string (mirrors
+// MemberNormalizer.ResolveBatch). In strict mode (effectiveIgnoreMissing
+// false), any resolution failure is fatal and the returned map must not be
+// trusted (the caller should stop on resp.Diagnostics.HasError()). In
+// ignore-missing mode, failures are reported as warnings and excluded from
+// the returned map; if every member fails to resolve, an error diagnostic is
+// added as a safety net to prevent accidentally emptying group membership.
+func (r *GroupMembershipResource) resolveMembers(
+	ctx context.Context,
+	normalizer *ldapclient.MemberNormalizer,
+	members []string,
+	effectiveIgnoreMissing bool,
+) (map[string]ldapclient.ResolvedIdentifier, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	resolvedMap, failures := normalizer.ResolveBatch(members)
+
+	// Handle any resolution failures
 	if len(failures) > 0 {
 		for identifier, err := range failures {
 			msg := fmt.Sprintf("Member '%s' could not be resolved: %s", identifier, err.Error())
@@ -240,53 +350,190 @@ func (r *GroupMembershipResource) ModifyPlan(ctx context.Context, req resource.M
 					"identifier": identifier,
 					"error":      err.Error(),
 				})
-				resp.Diagnostics.AddWarning("Member could not be resolved", msg)
+				diags.AddWarning("Member could not be resolved", msg)
 			} else {
-				resp.Diagnostics.AddError("Member could not be resolved", msg)
+				diags.AddError("Member could not be resolved", msg)
 			}
 		}
 
 		// In strict mode, stop if there are any errors
 		if !effectiveIgnoreMissing {
-			return
+			return resolvedMap, diags
 		}
 	}
 
-	// Extract normalized DNs in same order as input (only for successfully normalized members)
-	normalizedMembers := make([]string, 0, len(normalizedMap))
-	for _, member := range members {
-		if dn, ok := normalizedMap[member]; ok {
-			normalizedMembers = append(normalizedMembers, dn)
-		}
-		// Skip members that failed normalization (already reported above)
-	}
-
-	// Safety net: prevent accidental group emptying when all members fail normalization
-	if len(normalizedMembers) == 0 && len(members) > 0 {
-		resp.Diagnostics.AddError(
+	// Safety net: prevent accidental group emptying when all members fail resolution
+	if len(resolvedMap) == 0 && len(members) > 0 {
+		diags.AddError(
 			"All Members Failed to Resolve",
 			"All configured members failed normalization. Refusing to proceed with empty membership. "+
 				"Set ignore_missing_members = false to see individual errors, or remove invalid members from configuration.",
 		)
-		return
 	}
 
-	// Create the normalized members set and update the plan
-	membersNormalizedSet, diags := types.SetValueFrom(ctx, types.StringType, normalizedMembers)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	plan.MembersNormalized = membersNormalizedSet
+	return resolvedMap, diags
+}
 
-	tflog.Debug(ctx, "Normalized member identifiers during planning", map[string]any{
-		"group_id":           plan.GroupID.ValueString(),
-		"members":            members,
-		"normalized_members": normalizedMembers,
+// extractMemberDetailsForWrite unpacks data.MemberDetails — the plan-time-
+// resolved (dn, guid) pairs computed once by ModifyPlan — into the DN list
+// and DN->GUID map consumed by SetGroupMembers/AddGroupMembers to prefer
+// AD's rename-immune "<GUID=...>" alternative-DN form when writing newly-
+// added members.
+//
+// This is the common-case path for Create/Update and performs ZERO LDAP
+// calls: the (dn, guid) pairing was already resolved and correlated at the
+// schema level by ModifyPlan, so this is pure in-memory unpacking. It is
+// safe to trust member_details indefinitely through the apply because an
+// AD object's objectGUID never changes for its lifetime, unlike its DN
+// (which changes on rename) — capturing the GUID once, at plan time, is
+// therefore safe even if a referenced object is renamed by an unordered
+// sibling resource later in the very same apply: the write below uses the
+// GUID-alt-DN form for any member whose GUID is known, so AD itself
+// resolves it to whatever DN is current at write time, never the
+// (possibly stale) DN string captured in member_details.
+//
+// Callers must only invoke this when data.MemberDetails is known (neither
+// Unknown nor Null) — see resolveMembersForWriteFallback for the exception
+// path.
+func (r *GroupMembershipResource) extractMemberDetailsForWrite(
+	ctx context.Context, data *GroupMembershipResourceModel,
+) ([]string, map[string]string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var details []MemberDetailModel
+	diags.Append(data.MemberDetails.ElementsAs(ctx, &details, false)...)
+	if diags.HasError() {
+		return nil, nil, diags
+	}
+
+	memberDNs := make([]string, 0, len(details))
+	memberGUIDs := make(map[string]string, len(details))
+	for _, detail := range details {
+		dn := detail.DN.ValueString()
+		memberDNs = append(memberDNs, dn)
+		if guid := detail.GUID.ValueString(); guid != "" {
+			memberGUIDs[dn] = guid
+		}
+	}
+
+	return memberDNs, memberGUIDs, diags
+}
+
+// resolveMembersForWriteFallback re-resolves a resource's verbatim `members`
+// configuration fresh (live/cached), immediately before an AD write in
+// Create or Update. This is the EXCEPTION path, used ONLY when
+// data.MemberDetails is unknown or null — i.e. ModifyPlan itself could not
+// resolve members at plan time (e.g. a member is itself a new object being
+// created in the very same apply, referenced by a non-GUID identifier that
+// requires an LDAP lookup which can't succeed until the object exists). In
+// the common case (member_details fully known), Create/Update use
+// extractMemberDetailsForWrite instead, which performs zero LDAP calls.
+func (r *GroupMembershipResource) resolveMembersForWriteFallback(
+	ctx context.Context, data *GroupMembershipResourceModel,
+) ([]string, map[string]string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if data.Members.IsNull() || data.Members.IsUnknown() {
+		return nil, nil, diags
+	}
+
+	var members []string
+	diags.Append(data.Members.ElementsAs(ctx, &members, false)...)
+	if diags.HasError() {
+		return nil, nil, diags
+	}
+
+	if len(members) == 0 {
+		return []string{}, nil, diags
+	}
+
+	baseDN, err := r.client.GetBaseDN(ctx)
+	if err != nil {
+		diags.AddError(
+			"Error Getting Base DN",
+			fmt.Sprintf("Could not get base DN from LDAP client for member resolution: %s", err.Error()),
+		)
+		return nil, nil, diags
+	}
+
+	normalizer := ldapclient.NewMemberNormalizer(r.client, baseDN, r.cacheManager)
+	effectiveIgnoreMissing := r.effectiveIgnoreMissingMembers(ctx, data.IgnoreMissingMembers)
+
+	resolvedMap, resolveDiags := r.resolveMembers(ctx, normalizer, members, effectiveIgnoreMissing)
+	diags.Append(resolveDiags...)
+	if diags.HasError() {
+		return nil, nil, diags
+	}
+
+	// Build the DN list (same order as configured members) and the DN->GUID
+	// map used to prefer AD's rename-immune "<GUID=...>" alternative-DN form
+	// when writing newly-added members.
+	memberDNs := make([]string, 0, len(resolvedMap))
+	memberGUIDs := make(map[string]string, len(resolvedMap))
+	for _, member := range members {
+		resolved, ok := resolvedMap[member]
+		if !ok {
+			continue // failed resolution, already reported above (ignore-missing mode)
+		}
+		memberDNs = append(memberDNs, resolved.DN)
+		if resolved.GUID != "" {
+			memberGUIDs[resolved.DN] = resolved.GUID
+		}
+	}
+
+	return memberDNs, memberGUIDs, diags
+}
+
+// resolveMemberDetailsForWrite is the single entry point Create/Update use
+// to obtain the DN list and DN->GUID map for an AD membership write. It
+// takes the common-case, zero-LDAP-call path (extractMemberDetailsForWrite,
+// unpacking the plan-time snapshot in data.MemberDetails) unless that
+// snapshot is unknown or null, in which case it falls back to fresh
+// resolution (resolveMembersForWriteFallback) as the explicit exception.
+//
+// A types.Set populated by ModifyPlan is only ever Unknown/Null as a whole
+// (see ModifyPlan's doc comment) — never known-but-containing-individual-
+// unknown-elements — so checking IsUnknown()/IsNull() on the whole Set is
+// sufficient to detect the exception path; no per-element check is needed.
+//
+// In the fallback branch, data.MemberDetails is backfilled from the fresh
+// resolution before returning: Terraform requires every computed attribute
+// to be fully known once Create/Update completes, so an Unknown/Null
+// member_details can never be left as-is in the saved state — it must be
+// replaced with the same (dn, guid) pairs that were just resolved for the
+// write, keeping the persisted state internally consistent with what was
+// actually applied to AD.
+func (r *GroupMembershipResource) resolveMemberDetailsForWrite(
+	ctx context.Context, data *GroupMembershipResourceModel,
+) ([]string, map[string]string, diag.Diagnostics) {
+	if !data.MemberDetails.IsUnknown() && !data.MemberDetails.IsNull() {
+		return r.extractMemberDetailsForWrite(ctx, data)
+	}
+
+	tflog.Debug(ctx, "member_details unknown/null at apply time (ModifyPlan could not resolve members at plan time); falling back to fresh apply-time resolution", map[string]any{
+		"group_id": data.GroupID.ValueString(),
 	})
 
-	// Save the updated plan
-	resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+	memberDNs, memberGUIDs, diags := r.resolveMembersForWriteFallback(ctx, data)
+	if diags.HasError() {
+		return nil, nil, diags
+	}
+
+	details := make([]MemberDetailModel, 0, len(memberDNs))
+	for _, dn := range memberDNs {
+		details = append(details, MemberDetailModel{
+			DN:   types.StringValue(dn),
+			GUID: types.StringValue(memberGUIDs[dn]), // "" when absent, matching the empty-when-unavailable contract
+		})
+	}
+	memberDetailsSet, setDiags := types.SetValueFrom(ctx, memberDetailObjectType, details)
+	diags.Append(setDiags...)
+	if diags.HasError() {
+		return nil, nil, diags
+	}
+	data.MemberDetails = memberDetailsSet
+
+	return memberDNs, memberGUIDs, diags
 }
 
 // getMembershipManager creates a GroupMembershipManager from the client.
@@ -327,21 +574,29 @@ func (r *GroupMembershipResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	// Extract normalized member DNs from the plan (populated by ModifyPlan)
-	var normalizedMembers []string
-	resp.Diagnostics.Append(data.MembersNormalized.ElementsAs(ctx, &normalizedMembers, false)...)
+	// Use the plan-time-resolved (dn, guid) pairs captured in
+	// data.MemberDetails by ModifyPlan — the common case, requiring ZERO
+	// LDAP calls here. Falls back to fresh resolution only if
+	// member_details couldn't be resolved at plan time (see
+	// resolveMemberDetailsForWrite), in which case data.MemberDetails is
+	// backfilled from that fresh resolution so it is never left
+	// Unknown/Null in resp.State.Set below.
+	memberDNs, memberGUIDs, diags := r.resolveMemberDetailsForWrite(ctx, &data)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	tflog.Debug(ctx, "Setting group members using normalized DNs from plan", map[string]any{
-		"group_id":           data.GroupID.ValueString(),
-		"member_count":       len(normalizedMembers),
-		"normalized_members": normalizedMembers,
+	tflog.Debug(ctx, "Setting group members using plan-time-resolved details", map[string]any{
+		"group_id":     data.GroupID.ValueString(),
+		"member_count": len(memberDNs),
+		"member_dns":   memberDNs,
 	})
 
-	// Set the complete membership using normalized DNs
-	err = membershipManager.SetGroupMembers(data.GroupID.ValueString(), normalizedMembers)
+	// Set the complete membership using the resolved DNs, preferring AD's
+	// rename-immune "<GUID=...>" alternative-DN form for members whose
+	// GUID is known.
+	err = membershipManager.SetGroupMembers(data.GroupID.ValueString(), memberDNs, memberGUIDs)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Setting Group Members",
@@ -354,8 +609,8 @@ func (r *GroupMembershipResource) Create(ctx context.Context, req resource.Creat
 	data.ID = data.GroupID
 
 	tflog.Debug(ctx, "Created AD group membership", map[string]any{
-		"group_id":           data.GroupID.ValueString(),
-		"normalized_members": normalizedMembers,
+		"group_id":   data.GroupID.ValueString(),
+		"member_dns": memberDNs,
 	})
 
 	// Save data into Terraform state
@@ -449,21 +704,29 @@ func (r *GroupMembershipResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	// Extract normalized member DNs from the plan (populated by ModifyPlan)
-	var normalizedMembers []string
-	resp.Diagnostics.Append(data.MembersNormalized.ElementsAs(ctx, &normalizedMembers, false)...)
+	// Use the plan-time-resolved (dn, guid) pairs captured in
+	// data.MemberDetails by ModifyPlan — the common case, requiring ZERO
+	// LDAP calls here. Falls back to fresh resolution only if
+	// member_details couldn't be resolved at plan time (see
+	// resolveMemberDetailsForWrite), in which case data.MemberDetails is
+	// backfilled from that fresh resolution so it is never left
+	// Unknown/Null in resp.State.Set below.
+	memberDNs, memberGUIDs, diags := r.resolveMemberDetailsForWrite(ctx, &data)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	tflog.Debug(ctx, "Updating group members using normalized DNs from plan", map[string]any{
-		"group_id":           data.GroupID.ValueString(),
-		"member_count":       len(normalizedMembers),
-		"normalized_members": normalizedMembers,
+	tflog.Debug(ctx, "Updating group members using plan-time-resolved details", map[string]any{
+		"group_id":     data.GroupID.ValueString(),
+		"member_count": len(memberDNs),
+		"member_dns":   memberDNs,
 	})
 
-	// Set the complete membership using normalized DNs
-	err = membershipManager.SetGroupMembers(data.GroupID.ValueString(), normalizedMembers)
+	// Set the complete membership using the resolved DNs, preferring AD's
+	// rename-immune "<GUID=...>" alternative-DN form for members whose
+	// GUID is known.
+	err = membershipManager.SetGroupMembers(data.GroupID.ValueString(), memberDNs, memberGUIDs)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Updating Group Members",
@@ -473,8 +736,8 @@ func (r *GroupMembershipResource) Update(ctx context.Context, req resource.Updat
 	}
 
 	tflog.Debug(ctx, "Updated AD group membership", map[string]any{
-		"group_id":           data.GroupID.ValueString(),
-		"normalized_members": normalizedMembers,
+		"group_id":   data.GroupID.ValueString(),
+		"member_dns": memberDNs,
 	})
 
 	// Save updated data into Terraform state
@@ -507,8 +770,10 @@ func (r *GroupMembershipResource) Delete(ctx context.Context, req resource.Delet
 		return
 	}
 
-	// Clear all members from the group (empty slice means remove all)
-	err = membershipManager.SetGroupMembers(data.GroupID.ValueString(), []string{})
+	// Clear all members from the group (empty slice means remove all). No
+	// member-identity resolution is needed here: removing everyone needs no
+	// GUID map, and passing nil for an empty add-list is a no-op regardless.
+	err = membershipManager.SetGroupMembers(data.GroupID.ValueString(), []string{}, nil)
 	if err != nil {
 		// If the group no longer exists, that's fine - the membership is effectively deleted
 		if ldapErr, ok := err.(*ldapclient.LDAPError); ok {
@@ -552,7 +817,7 @@ func (r *GroupMembershipResource) ImportState(ctx context.Context, req resource.
 
 	// Normalize the import ID to a DN (supports DN, GUID, SID, UPN, SAM formats)
 	normalizer := ldapclient.NewMemberNormalizer(r.client, baseDN, r.cacheManager)
-	groupDN, err := normalizer.NormalizeToDN(importID)
+	resolved, err := normalizer.Resolve(importID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Resolving Group Identifier",
@@ -560,6 +825,7 @@ func (r *GroupMembershipResource) ImportState(ctx context.Context, req resource.
 		)
 		return
 	}
+	groupDN := resolved.DN
 
 	tflog.Debug(ctx, "Resolved group identifier to DN", map[string]any{
 		"import_id": importID,
@@ -610,8 +876,10 @@ func (r *GroupMembershipResource) ImportState(ctx context.Context, req resource.
 	data.ID = types.StringValue(groupGUID)
 	data.GroupID = types.StringValue(groupGUID)
 
-	// For import, set both Members and MembersNormalized to the DNs from AD
-	// Users can then update their configuration to use their preferred identifier format
+	// For import, set Members to the plain DNs from AD (users can then
+	// update their configuration to use their preferred identifier format)
+	// and member_details to those same DNs paired with their resolved
+	// GUIDs.
 	if len(currentMembers) > 0 {
 		membersSet, diags := types.SetValueFrom(ctx, types.StringType, currentMembers)
 		resp.Diagnostics.Append(diags...)
@@ -619,12 +887,17 @@ func (r *GroupMembershipResource) ImportState(ctx context.Context, req resource.
 			return
 		}
 		data.Members = membersSet
-		data.MembersNormalized = membersSet
+
+		memberDetailsSet, diags := r.resolveCurrentMemberDetails(ctx, currentMembers)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.MemberDetails = memberDetailsSet
 	} else {
 		// Empty membership
-		emptySet := types.SetValueMust(types.StringType, []attr.Value{})
-		data.Members = emptySet
-		data.MembersNormalized = emptySet
+		data.Members = types.SetValueMust(types.StringType, []attr.Value{})
+		data.MemberDetails = types.SetValueMust(memberDetailObjectType, []attr.Value{})
 	}
 
 	tflog.Info(ctx, "Successfully imported AD group membership", map[string]any{
@@ -641,8 +914,74 @@ func (r *GroupMembershipResource) ImportState(ctx context.Context, req resource.
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), groupGUID)...)
 }
 
+// resolveCurrentMemberDetails resolves each of the given (already-canonical)
+// member DNs — as read live from AD's own `member` attribute — to its
+// (dn, guid) pair, for use outside of ModifyPlan (Read/refreshMembershipState
+// and ImportState, which start from AD's actual current membership rather
+// than from the user's verbatim `members` configuration).
+//
+// This deliberately performs a full live-or-cached resolution per DN (via
+// MemberNormalizer.ResolveBatch, which checks the shared cache before
+// falling back to LDAP) rather than a cache-only best-effort lookup: a
+// cache-only lookup would only ever hit for a DN some earlier resolution in
+// this same provider process already cached, which is not guaranteed for
+// every real `terraform plan`/`apply` invocation (each is normally a fresh
+// process with an empty cache). Resolving fully here ensures Read produces
+// the exact same (dn, guid) pairs ModifyPlan would independently compute for
+// the same DN, so a steady-state refresh (no actual AD membership change)
+// converges to zero plan diff instead of a spurious one from a mismatched
+// `guid` sub-field.
+//
+// A resolution failure for an individual member (e.g. it was deleted
+// between the group-members read and this call) is non-fatal: it is logged
+// and that member's GUID is left as the empty string, consistent with
+// ResolvedIdentifier's "GUID empty when unavailable" contract.
+func (r *GroupMembershipResource) resolveCurrentMemberDetails(ctx context.Context, memberDNs []string) (types.Set, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if len(memberDNs) == 0 {
+		set, setDiags := types.SetValue(memberDetailObjectType, []attr.Value{})
+		diags.Append(setDiags...)
+		return set, diags
+	}
+
+	baseDN, err := r.client.GetBaseDN(ctx)
+	if err != nil {
+		diags.AddError(
+			"Error Getting Base DN",
+			fmt.Sprintf("Could not get base DN from LDAP client for member GUID resolution: %s", err.Error()),
+		)
+		return types.SetNull(memberDetailObjectType), diags
+	}
+
+	normalizer := ldapclient.NewMemberNormalizer(r.client, baseDN, r.cacheManager)
+	resolvedMap, failures := normalizer.ResolveBatch(memberDNs)
+	for dn, resolveErr := range failures {
+		tflog.Warn(ctx, "Could not resolve current member's GUID; member_details.guid will be empty for this member", map[string]any{
+			"dn":    dn,
+			"error": resolveErr.Error(),
+		})
+	}
+
+	details := make([]MemberDetailModel, 0, len(memberDNs))
+	for _, dn := range memberDNs {
+		guid := ""
+		if resolved, ok := resolvedMap[dn]; ok {
+			guid = resolved.GUID
+		}
+		details = append(details, MemberDetailModel{
+			DN:   types.StringValue(dn),
+			GUID: types.StringValue(guid),
+		})
+	}
+
+	set, setDiags := types.SetValueFrom(ctx, memberDetailObjectType, details)
+	diags.Append(setDiags...)
+	return set, diags
+}
+
 // refreshMembershipState updates the model with current membership from Active Directory.
-// This updates ONLY the MembersNormalized attribute with current AD state,
+// This updates ONLY the MemberDetails attribute with current AD state,
 // preserving the user's original configuration in the Members attribute.
 func (r *GroupMembershipResource) refreshMembershipState(ctx context.Context, membershipManager *ldapclient.GroupMembershipManager, model *GroupMembershipResourceModel) error {
 	// Get current members from AD (already normalized as DNs)
@@ -653,17 +992,17 @@ func (r *GroupMembershipResource) refreshMembershipState(ctx context.Context, me
 
 	// DO NOT touch model.Members - preserve user's original configuration!
 
-	// Only update MembersNormalized with current AD state
-	membersNormalizedSet, diags := types.SetValueFrom(ctx, types.StringType, currentMembers)
+	// Only update MemberDetails with current AD state
+	memberDetailsSet, diags := r.resolveCurrentMemberDetails(ctx, currentMembers)
 	if diags.HasError() {
-		return fmt.Errorf("could not create normalized members set: %v", diags.Errors())
+		return fmt.Errorf("could not create member details set: %v", diags.Errors())
 	}
-	model.MembersNormalized = membersNormalizedSet
+	model.MemberDetails = memberDetailsSet
 
 	tflog.Trace(ctx, "Refreshed membership state", map[string]any{
-		"group_id":           model.GroupID.ValueString(),
-		"member_count":       len(currentMembers),
-		"normalized_members": currentMembers,
+		"group_id":     model.GroupID.ValueString(),
+		"member_count": len(currentMembers),
+		"members":      currentMembers,
 	})
 
 	return nil

--- a/internal/provider/resource_group_membership.go
+++ b/internal/provider/resource_group_membership.go
@@ -41,19 +41,20 @@ type GroupMembershipResourceModel struct {
 	ID                   types.String `tfsdk:"id"`                     // Group objectGUID (same as group_id)
 	GroupID              types.String `tfsdk:"group_id"`               // Group objectGUID (required)
 	Members              types.Set    `tfsdk:"members"`                // Set of member identifiers (required, user-provided)
-	MemberDetails        types.Set    `tfsdk:"member_details"`         // Set of MemberDetailModel: resolved (dn, guid) pairs (computed)
+	MemberDetails        types.Set    `tfsdk:"member_details"`         // Set of MemberDetailModel: resolved (dn, id) pairs (computed)
 	IgnoreMissingMembers types.Bool   `tfsdk:"ignore_missing_members"` // Per-resource override for ignore_missing_members (optional)
 }
 
 // MemberDetailModel describes a single resolved member — one element of
-// MemberDetails. DN and GUID are correlated together (unlike two independent
-// flat Sets, which would lose that correlation): both are derived from the
-// same identifier, in the same ModifyPlan resolution pass, from whatever
-// format was used in `members`. GUID is the empty string when unavailable
-// (mirrors ldapclient.ResolvedIdentifier; never an error on its own).
+// MemberDetails. DN and ID (the member's objectGUID) are correlated together
+// (unlike two independent flat Sets, which would lose that correlation): both
+// are derived from the same identifier, in the same ModifyPlan resolution
+// pass, from whatever format was used in `members`. ID is the empty string
+// when unavailable (mirrors ldapclient.ResolvedIdentifier; never an error on
+// its own).
 type MemberDetailModel struct {
-	DN   types.String `tfsdk:"dn"`
-	GUID types.String `tfsdk:"guid"`
+	DN types.String `tfsdk:"dn"`
+	ID types.String `tfsdk:"id"`
 }
 
 // memberDetailAttrTypes/memberDetailObjectType describe the element type of
@@ -62,8 +63,8 @@ type MemberDetailModel struct {
 // schema.Schema definition itself (ModifyPlan, Create/Update, Read,
 // ImportState).
 var memberDetailAttrTypes = map[string]attr.Type{
-	"dn":   types.StringType,
-	"guid": types.StringType,
+	"dn": types.StringType,
+	"id": types.StringType,
 }
 
 var memberDetailObjectType = types.ObjectType{AttrTypes: memberDetailAttrTypes}
@@ -76,7 +77,7 @@ func (r *GroupMembershipResource) Schema(ctx context.Context, req resource.Schem
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages the membership of an Active Directory group. This resource allows you to define the complete set of members for a group, with automatic anti-drift protection through identifier normalization.\n\n" +
 			"**Anti-Drift Protection**: This resource automatically normalizes all member identifiers to distinguished names (DNs) and object GUIDs internally while preserving your original configuration. " +
-			"The `members` attribute retains exactly what you configure, while `member_details` shows the resolved `(dn, guid)` pairs used for Active Directory operations. " +
+			"The `members` attribute retains exactly what you configure, while `member_details` shows the resolved `(dn, id)` pairs used for Active Directory operations. " +
 			"Resolution happens once, at plan time; because an object's `objectGUID` never changes for its lifetime (unlike its DN, which changes on rename), that plan-time snapshot is trusted for the rest of the apply.\n\n" +
 			"**Supported Identifier Formats**:\n" +
 			"- Distinguished Name (DN): `CN=John Doe,OU=Users,DC=example,DC=com`\n" +
@@ -117,8 +118,8 @@ func (r *GroupMembershipResource) Schema(ctx context.Context, req resource.Schem
 				Computed: true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"dn":   schema.StringAttribute{Computed: true, MarkdownDescription: "The member's distinguished name."},
-						"guid": schema.StringAttribute{Computed: true, MarkdownDescription: "The member's objectGUID (canonical hyphenated form)."},
+						"dn": schema.StringAttribute{Computed: true, MarkdownDescription: "The member's distinguished name."},
+						"id": schema.StringAttribute{Computed: true, MarkdownDescription: "The member's objectGUID (canonical hyphenated form)."},
 					},
 				},
 			},
@@ -260,15 +261,15 @@ func (r *GroupMembershipResource) ModifyPlan(ctx context.Context, req resource.M
 		return
 	}
 
-	// Build the resolved (dn, guid) pairs in the same order as input (only
+	// Build the resolved (dn, id) pairs in the same order as input (only
 	// for successfully resolved members). Both DN and GUID come from the
 	// SAME ResolvedIdentifier, so they are correlated by construction.
 	memberDetails := make([]MemberDetailModel, 0, len(resolvedMap))
 	for _, member := range members {
 		if resolved, ok := resolvedMap[member]; ok {
 			memberDetails = append(memberDetails, MemberDetailModel{
-				DN:   types.StringValue(resolved.DN),
-				GUID: types.StringValue(resolved.GUID),
+				DN: types.StringValue(resolved.DN),
+				ID: types.StringValue(resolved.GUID),
 			})
 		}
 		// Skip members that failed normalization (already reported above)
@@ -375,13 +376,13 @@ func (r *GroupMembershipResource) resolveMembers(
 }
 
 // extractMemberDetailsForWrite unpacks data.MemberDetails — the plan-time-
-// resolved (dn, guid) pairs computed once by ModifyPlan — into the DN list
+// resolved (dn, id) pairs computed once by ModifyPlan — into the DN list
 // and DN->GUID map consumed by SetGroupMembers/AddGroupMembers to prefer
 // AD's rename-immune "<GUID=...>" alternative-DN form when writing newly-
 // added members.
 //
 // This is the common-case path for Create/Update and performs ZERO LDAP
-// calls: the (dn, guid) pairing was already resolved and correlated at the
+// calls: the (dn, id) pairing was already resolved and correlated at the
 // schema level by ModifyPlan, so this is pure in-memory unpacking. It is
 // safe to trust member_details indefinitely through the apply because an
 // AD object's objectGUID never changes for its lifetime, unlike its DN
@@ -411,7 +412,7 @@ func (r *GroupMembershipResource) extractMemberDetailsForWrite(
 	for _, detail := range details {
 		dn := detail.DN.ValueString()
 		memberDNs = append(memberDNs, dn)
-		if guid := detail.GUID.ValueString(); guid != "" {
+		if guid := detail.ID.ValueString(); guid != "" {
 			memberGUIDs[dn] = guid
 		}
 	}
@@ -500,7 +501,7 @@ func (r *GroupMembershipResource) resolveMembersForWriteFallback(
 // resolution before returning: Terraform requires every computed attribute
 // to be fully known once Create/Update completes, so an Unknown/Null
 // member_details can never be left as-is in the saved state — it must be
-// replaced with the same (dn, guid) pairs that were just resolved for the
+// replaced with the same (dn, id) pairs that were just resolved for the
 // write, keeping the persisted state internally consistent with what was
 // actually applied to AD.
 func (r *GroupMembershipResource) resolveMemberDetailsForWrite(
@@ -522,8 +523,8 @@ func (r *GroupMembershipResource) resolveMemberDetailsForWrite(
 	details := make([]MemberDetailModel, 0, len(memberDNs))
 	for _, dn := range memberDNs {
 		details = append(details, MemberDetailModel{
-			DN:   types.StringValue(dn),
-			GUID: types.StringValue(memberGUIDs[dn]), // "" when absent, matching the empty-when-unavailable contract
+			DN: types.StringValue(dn),
+			ID: types.StringValue(memberGUIDs[dn]), // "" when absent, matching the empty-when-unavailable contract
 		})
 	}
 	memberDetailsSet, setDiags := types.SetValueFrom(ctx, memberDetailObjectType, details)
@@ -574,7 +575,7 @@ func (r *GroupMembershipResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	// Use the plan-time-resolved (dn, guid) pairs captured in
+	// Use the plan-time-resolved (dn, id) pairs captured in
 	// data.MemberDetails by ModifyPlan — the common case, requiring ZERO
 	// LDAP calls here. Falls back to fresh resolution only if
 	// member_details couldn't be resolved at plan time (see
@@ -704,7 +705,7 @@ func (r *GroupMembershipResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	// Use the plan-time-resolved (dn, guid) pairs captured in
+	// Use the plan-time-resolved (dn, id) pairs captured in
 	// data.MemberDetails by ModifyPlan — the common case, requiring ZERO
 	// LDAP calls here. Falls back to fresh resolution only if
 	// member_details couldn't be resolved at plan time (see
@@ -916,7 +917,7 @@ func (r *GroupMembershipResource) ImportState(ctx context.Context, req resource.
 
 // resolveCurrentMemberDetails resolves each of the given (already-canonical)
 // member DNs — as read live from AD's own `member` attribute — to its
-// (dn, guid) pair, for use outside of ModifyPlan (Read/refreshMembershipState
+// (dn, id) pair, for use outside of ModifyPlan (Read/refreshMembershipState
 // and ImportState, which start from AD's actual current membership rather
 // than from the user's verbatim `members` configuration).
 //
@@ -927,10 +928,10 @@ func (r *GroupMembershipResource) ImportState(ctx context.Context, req resource.
 // this same provider process already cached, which is not guaranteed for
 // every real `terraform plan`/`apply` invocation (each is normally a fresh
 // process with an empty cache). Resolving fully here ensures Read produces
-// the exact same (dn, guid) pairs ModifyPlan would independently compute for
+// the exact same (dn, id) pairs ModifyPlan would independently compute for
 // the same DN, so a steady-state refresh (no actual AD membership change)
 // converges to zero plan diff instead of a spurious one from a mismatched
-// `guid` sub-field.
+// `id` sub-field.
 //
 // A resolution failure for an individual member (e.g. it was deleted
 // between the group-members read and this call) is non-fatal: it is logged
@@ -957,7 +958,7 @@ func (r *GroupMembershipResource) resolveCurrentMemberDetails(ctx context.Contex
 	normalizer := ldapclient.NewMemberNormalizer(r.client, baseDN, r.cacheManager)
 	resolvedMap, failures := normalizer.ResolveBatch(memberDNs)
 	for dn, resolveErr := range failures {
-		tflog.Warn(ctx, "Could not resolve current member's GUID; member_details.guid will be empty for this member", map[string]any{
+		tflog.Warn(ctx, "Could not resolve current member's GUID; member_details.id will be empty for this member", map[string]any{
 			"dn":    dn,
 			"error": resolveErr.Error(),
 		})
@@ -970,8 +971,8 @@ func (r *GroupMembershipResource) resolveCurrentMemberDetails(ctx context.Contex
 			guid = resolved.GUID
 		}
 		details = append(details, MemberDetailModel{
-			DN:   types.StringValue(dn),
-			GUID: types.StringValue(guid),
+			DN: types.StringValue(dn),
+			ID: types.StringValue(guid),
 		})
 	}
 

--- a/internal/provider/resource_group_membership_apply_test.go
+++ b/internal/provider/resource_group_membership_apply_test.go
@@ -1,0 +1,550 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/go-ldap/ldap/v3"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	ldapclient "github.com/isometry/terraform-provider-ad/internal/ldap"
+)
+
+// recordingMembershipClient is a minimal ldapclient.Client implementation
+// that fakes a single AD group, for driving GroupMembershipResource.Create
+// and Update against a real (in-memory) group-membership write path.
+//
+// Unlike stubMembershipClient (in resource_group_membership_internal_test.go,
+// which drives ModifyPlan only: its Modify is a no-op and its Search fails
+// loudly by design), this stub (a) records every Modify request issued so
+// tests can assert on exactly what was submitted to AD's `member` attribute,
+// and (b) answers the Search call GetGroupMembers/AddGroupMembers/
+// RemoveGroupMembers issue (via GroupManager.GetGroup's GUID lookup) with a
+// controllable, mutable fake current-membership list.
+type recordingMembershipClient struct {
+	baseDN string
+
+	groupGUID string
+	groupDN   string
+	members   []string // current group membership (DNs); mutated by Modify
+
+	modifyRequests []*ldapclient.ModifyRequest
+	searchFilters  []string // every Search filter received, in call order
+}
+
+var _ ldapclient.Client = (*recordingMembershipClient)(nil)
+
+// newRecordingMembershipClient constructs a recordingMembershipClient faking
+// a single group identified by groupGUID/groupDN, with the given current
+// members.
+func newRecordingMembershipClient(groupGUID, groupDN string, initialMembers ...string) *recordingMembershipClient {
+	members := make([]string, len(initialMembers))
+	copy(members, initialMembers)
+	return &recordingMembershipClient{
+		baseDN:    "DC=example,DC=com",
+		groupGUID: groupGUID,
+		groupDN:   groupDN,
+		members:   members,
+	}
+}
+
+func (c *recordingMembershipClient) Connect(ctx context.Context) error { return nil }
+func (c *recordingMembershipClient) Close() error                      { return nil }
+
+func (c *recordingMembershipClient) Bind(ctx context.Context, username, password string) error {
+	return nil
+}
+
+func (c *recordingMembershipClient) BindWithConfig(ctx context.Context) error { return nil }
+
+func (c *recordingMembershipClient) GetBaseDN(ctx context.Context) (string, error) {
+	return c.baseDN, nil
+}
+
+func (c *recordingMembershipClient) Ping(ctx context.Context) error { return nil }
+
+func (c *recordingMembershipClient) Stats() ldapclient.PoolStats { return ldapclient.PoolStats{} }
+
+func (c *recordingMembershipClient) GetRootDSE(ctx context.Context) (*ldapclient.RootDSEInfo, error) {
+	return nil, fmt.Errorf("recordingMembershipClient: GetRootDSE not implemented")
+}
+
+func (c *recordingMembershipClient) WhoAmI(ctx context.Context) (*ldapclient.WhoAmIResult, error) {
+	return nil, fmt.Errorf("recordingMembershipClient: WhoAmI not implemented")
+}
+
+func (c *recordingMembershipClient) Add(ctx context.Context, req *ldapclient.AddRequest) error {
+	return fmt.Errorf("recordingMembershipClient: unexpected Add call")
+}
+
+func (c *recordingMembershipClient) ModifyDN(ctx context.Context, req *ldapclient.ModifyDNRequest) error {
+	return fmt.Errorf("recordingMembershipClient: unexpected ModifyDN call")
+}
+
+func (c *recordingMembershipClient) Delete(ctx context.Context, dn string) error {
+	return fmt.Errorf("recordingMembershipClient: unexpected Delete call")
+}
+
+func (c *recordingMembershipClient) SearchWithPaging(ctx context.Context, req *ldapclient.SearchRequest) (*ldapclient.SearchResult, error) {
+	return c.Search(ctx, req)
+}
+
+// Search answers only the group-by-GUID lookup issued by
+// GroupManager.GetGroup (used by GetGroupMembers/AddGroupMembers/
+// RemoveGroupMembers to fetch the group's DN and current member list). Any
+// other Search call indicates a test setup bug (e.g. a member identifier
+// that was not pre-seeded into the cache manager, forcing a live lookup)
+// and fails loudly rather than silently attempting network I/O. Every
+// filter received (including group-by-GUID lookups) is recorded in
+// searchFilters so tests can assert on exactly what LDAP searches occurred.
+func (c *recordingMembershipClient) Search(ctx context.Context, req *ldapclient.SearchRequest) (*ldapclient.SearchResult, error) {
+	filter := ""
+	if req != nil {
+		filter = req.Filter
+	}
+	c.searchFilters = append(c.searchFilters, filter)
+	if strings.Contains(filter, "objectGUID=") {
+		return &ldapclient.SearchResult{Entries: []*ldap.Entry{c.groupEntry()}, Total: 1}, nil
+	}
+	return nil, fmt.Errorf("recordingMembershipClient: unexpected Search(%q) — identifier should have been cache-resolved", filter)
+}
+
+func (c *recordingMembershipClient) groupEntry() *ldap.Entry {
+	guidBytes, _ := ldapclient.NewGUIDHandler().StringToGUIDBytes(c.groupGUID)
+	attributes := []*ldap.EntryAttribute{
+		{Name: "objectGUID", ByteValues: [][]byte{guidBytes}},
+		{Name: "distinguishedName", Values: []string{c.groupDN}},
+		{Name: "cn", Values: []string{"TestGroup"}},
+	}
+	if len(c.members) > 0 {
+		attributes = append(attributes, &ldap.EntryAttribute{
+			Name:   "member",
+			Values: append([]string(nil), c.members...),
+		})
+	}
+	return &ldap.Entry{DN: c.groupDN, Attributes: attributes}
+}
+
+// Modify records every request submitted and applies it to the in-memory
+// member list, so that subsequent Search-driven lookups within the same
+// SetGroupMembers call (e.g. RemoveGroupMembers re-reading current state
+// after AddGroupMembers already ran) see up-to-date membership.
+func (c *recordingMembershipClient) Modify(ctx context.Context, req *ldapclient.ModifyRequest) error {
+	c.modifyRequests = append(c.modifyRequests, req)
+
+	if add, ok := req.AddAttributes["member"]; ok {
+		c.members = append(c.members, add...)
+	}
+	if replace, ok := req.ReplaceAttributes["member"]; ok {
+		c.members = append([]string(nil), replace...)
+	}
+	for _, attr := range req.DeleteAttributes {
+		if attr == "member" {
+			c.members = nil
+		}
+	}
+
+	return nil
+}
+
+// addedMemberValues returns every value submitted via
+// ModifyRequest.AddAttributes["member"] across all recorded Modify calls, in
+// call order. This is what actually got written to AD's member attribute
+// for newly-added members (post GUID-alt-DN substitution, if applicable).
+func (c *recordingMembershipClient) addedMemberValues() []string {
+	var out []string
+	for _, req := range c.modifyRequests {
+		out = append(out, req.AddAttributes["member"]...)
+	}
+	return out
+}
+
+// newTestGroupMembershipResourceWithClient constructs a
+// GroupMembershipResource wired to the given client and cache manager, for
+// driving Create/Update directly without a real provider server or live
+// LDAP connection.
+func newTestGroupMembershipResourceWithClient(client ldapclient.Client, cm *ldapclient.CacheManager) *GroupMembershipResource {
+	return &GroupMembershipResource{
+		client:               client,
+		cacheManager:         cm,
+		ignoreMissingMembers: false,
+	}
+}
+
+// runMembershipCreate drives GroupMembershipResource.Create with the given
+// plan model and returns the resulting state model alongside the response.
+func runMembershipCreate(
+	t *testing.T, ctx context.Context, r *GroupMembershipResource, planModel *GroupMembershipResourceModel,
+) (*GroupMembershipResourceModel, *resource.CreateResponse) {
+	t.Helper()
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	tfType := schemaResp.Schema.Type().TerraformType(ctx)
+
+	plan := tfsdk.Plan{Schema: schemaResp.Schema, Raw: tftypes.NewValue(tfType, nil)}
+	if diags := plan.Set(ctx, planModel); diags.HasError() {
+		t.Fatalf("failed to build plan: %v", diags.Errors())
+	}
+
+	req := resource.CreateRequest{Plan: plan}
+	// The real framework runtime pre-populates resp.State from req.Plan
+	// before invoking Create; mirror that here.
+	resp := &resource.CreateResponse{
+		State: tfsdk.State{Schema: schemaResp.Schema, Raw: tftypes.NewValue(tfType, nil)},
+	}
+	if diags := resp.State.Set(ctx, planModel); diags.HasError() {
+		t.Fatalf("failed to seed resp.State from plan: %v", diags.Errors())
+	}
+
+	r.Create(ctx, req, resp)
+
+	var out GroupMembershipResourceModel
+	if !resp.State.Raw.IsNull() {
+		if diags := resp.State.Get(ctx, &out); diags.HasError() {
+			t.Fatalf("failed to extract resulting state: %v", diags.Errors())
+		}
+	}
+	return &out, resp
+}
+
+// runMembershipUpdate drives GroupMembershipResource.Update with the given
+// plan/prior-state models and returns the resulting state model alongside
+// the response.
+func runMembershipUpdate(
+	t *testing.T, ctx context.Context, r *GroupMembershipResource, planModel, stateModel *GroupMembershipResourceModel,
+) (*GroupMembershipResourceModel, *resource.UpdateResponse) {
+	t.Helper()
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	tfType := schemaResp.Schema.Type().TerraformType(ctx)
+
+	plan := tfsdk.Plan{Schema: schemaResp.Schema, Raw: tftypes.NewValue(tfType, nil)}
+	if diags := plan.Set(ctx, planModel); diags.HasError() {
+		t.Fatalf("failed to build plan: %v", diags.Errors())
+	}
+
+	state := tfsdk.State{Schema: schemaResp.Schema, Raw: tftypes.NewValue(tfType, nil)}
+	if diags := state.Set(ctx, stateModel); diags.HasError() {
+		t.Fatalf("failed to build prior state: %v", diags.Errors())
+	}
+
+	req := resource.UpdateRequest{Plan: plan, State: state}
+	// The real framework runtime pre-populates resp.State from req.Plan
+	// before invoking Update; mirror that here.
+	resp := &resource.UpdateResponse{
+		State: tfsdk.State{Schema: schemaResp.Schema, Raw: tftypes.NewValue(tfType, nil)},
+	}
+	if diags := resp.State.Set(ctx, planModel); diags.HasError() {
+		t.Fatalf("failed to seed resp.State from plan: %v", diags.Errors())
+	}
+
+	r.Update(ctx, req, resp)
+
+	var out GroupMembershipResourceModel
+	if !resp.State.Raw.IsNull() {
+		if diags := resp.State.Get(ctx, &out); diags.HasError() {
+			t.Fatalf("failed to extract resulting state: %v", diags.Errors())
+		}
+	}
+	return &out, resp
+}
+
+// nonGroupLookupSearches returns every recorded Search filter that was NOT
+// the "objectGUID=" group-by-GUID lookup GetGroupMembers/AddGroupMembers/
+// RemoveGroupMembers legitimately issue. In the new plan-time-GUID-capture
+// design this must always be empty for Create/Update's common case (fully
+// known member_details): resolving member identities happens ZERO times at
+// apply time, so the only Search traffic at all is the group's own DN/
+// current-member lookup.
+func (c *recordingMembershipClient) nonGroupLookupSearches() []string {
+	var out []string
+	for _, filter := range c.searchFilters {
+		if !strings.Contains(filter, "objectGUID=") {
+			out = append(out, filter)
+		}
+	}
+	return out
+}
+
+// TestGroupMembershipResource_CreateUpdateTrustPlanTimeMemberDetails is the
+// direct regression test for the design that replaced apply-time
+// re-resolution (re-resolving `members` fresh, live/cached, immediately
+// before the AD write) with plan-time GUID capture: `member_details` is
+// resolved exactly once, by ModifyPlan, and trusted verbatim through apply.
+// This is safe — even if a referenced object is renamed by an unordered
+// sibling resource later in the very same apply — because an AD object's
+// objectGUID never changes for its lifetime, and the write below always
+// prefers the GUID-alt-DN form over the literal (possibly now-stale) DN
+// string.
+//
+// Each subtest hand-constructs a model where MemberDetails already holds a
+// resolved (dn, guid) pair whose dn deliberately looks "stale", as if
+// captured before some unrelated rename — and deliberately does NOT seed
+// the cache manager for that identifier. recordingMembershipClient fails
+// loudly on any Search beyond the legitimate group-by-GUID lookup, so if
+// Create/Update regressed to re-resolving `members` fresh (the old design),
+// that re-resolution would require a live Search this stub does not answer
+// for a bare identifier, failing the test loudly rather than silently
+// succeeding. Invariants asserted:
+//
+//  1. The underlying AD write uses member_details' captured GUID (via its
+//     "<GUID=...>" alternative-DN form) — proving the write is driven by
+//     member_details, not by any re-resolution of `members`.
+//  2. Every Search call recorded is the legitimate group-by-GUID lookup —
+//     zero LDAP calls were made to resolve member identity.
+//  3. resp.State's saved member_details equals exactly what ModifyPlan had
+//     already captured in the input plan — proving Create/Update never
+//     rewrite it in the common case.
+func TestGroupMembershipResource_CreateUpdateTrustPlanTimeMemberDetails(t *testing.T) {
+	ctx := t.Context()
+
+	const (
+		memberDN   = "CN=CapturedAtPlanTime,OU=Users,DC=example,DC=com"
+		memberGUID = "11111111-1111-1111-1111-111111111111"
+
+		groupGUID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+		groupDN   = "CN=TestGroup,OU=Groups,DC=example,DC=com"
+	)
+
+	expectedAltDN, err := ldapclient.GUIDToAltDN(memberGUID)
+	if err != nil {
+		t.Fatalf("failed to compute expected alt-DN: %v", err)
+	}
+
+	t.Run("Create", func(t *testing.T) {
+		client := newRecordingMembershipClient(groupGUID, groupDN) // no members yet
+		// Deliberately an empty, unseeded cache manager: extracting the
+		// write from member_details must need no cache lookup at all.
+		r := newTestGroupMembershipResourceWithClient(client, ldapclient.NewCacheManager())
+
+		planModel := &GroupMembershipResourceModel{
+			ID:                   types.StringUnknown(),
+			GroupID:              types.StringValue(groupGUID),
+			Members:              newMembershipSet(t, memberGUID),
+			MemberDetails:        newMemberDetailSet(t, ctx, []string{memberDN}, []string{memberGUID}),
+			IgnoreMissingMembers: types.BoolNull(),
+		}
+
+		out, resp := runMembershipCreate(t, ctx, r, planModel)
+		if resp.Diagnostics.HasError() {
+			t.Fatalf("unexpected error: %v", resp.Diagnostics.Errors())
+		}
+
+		// Invariant 1: the AD write used member_details' GUID-alt-DN form.
+		added := client.addedMemberValues()
+		if len(added) != 1 || added[0] != expectedAltDN {
+			t.Errorf("AD write used %v, want [%q] (member_details' GUID-alt-DN form)", added, expectedAltDN)
+		}
+
+		// Invariant 2: zero LDAP calls were made to resolve member identity.
+		if extra := client.nonGroupLookupSearches(); len(extra) != 0 {
+			t.Errorf("unexpected member-identity-resolution Search calls: %v", extra)
+		}
+
+		// Invariant 3 (consistency guard): member_details in the saved
+		// state must remain exactly what the plan already had.
+		gotDetails := extractMemberDetails(t, ctx, out.MemberDetails)
+		wantDetails := extractMemberDetails(t, ctx, planModel.MemberDetails)
+		if len(gotDetails) != len(wantDetails) {
+			t.Fatalf("member_details = %v, want %v", gotDetails, wantDetails)
+		}
+		for dn, guid := range wantDetails {
+			if gotDetails[dn] != guid {
+				t.Errorf("member_details[%q] = %q, want %q (must equal plan's value verbatim)", dn, gotDetails[dn], guid)
+			}
+		}
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		const dnOld = "CN=OldMember,OU=Users,DC=example,DC=com"
+		client := newRecordingMembershipClient(groupGUID, groupDN, dnOld) // pre-existing, unrelated member
+		r := newTestGroupMembershipResourceWithClient(client, ldapclient.NewCacheManager())
+
+		planModel := &GroupMembershipResourceModel{
+			ID:                   types.StringValue(groupGUID),
+			GroupID:              types.StringValue(groupGUID),
+			Members:              newMembershipSet(t, memberGUID),
+			MemberDetails:        newMemberDetailSet(t, ctx, []string{memberDN}, []string{memberGUID}),
+			IgnoreMissingMembers: types.BoolNull(),
+		}
+		stateModel := &GroupMembershipResourceModel{
+			ID:                   types.StringValue(groupGUID),
+			GroupID:              types.StringValue(groupGUID),
+			Members:              newMembershipSet(t, dnOld),
+			MemberDetails:        newMemberDetailSet(t, ctx, []string{dnOld}, []string{""}),
+			IgnoreMissingMembers: types.BoolNull(),
+		}
+
+		out, resp := runMembershipUpdate(t, ctx, r, planModel, stateModel)
+		if resp.Diagnostics.HasError() {
+			t.Fatalf("unexpected error: %v", resp.Diagnostics.Errors())
+		}
+
+		// Invariant 1: the AD write used member_details' GUID-alt-DN form.
+		added := client.addedMemberValues()
+		if len(added) != 1 || added[0] != expectedAltDN {
+			t.Errorf("AD write used %v, want [%q] (member_details' GUID-alt-DN form)", added, expectedAltDN)
+		}
+
+		// The old, no-longer-desired member must have been removed.
+		if len(client.members) != 1 || client.members[0] != expectedAltDN {
+			t.Errorf("final group membership = %v, want [%q]", client.members, expectedAltDN)
+		}
+
+		// Invariant 2: zero LDAP calls were made to resolve member identity.
+		if extra := client.nonGroupLookupSearches(); len(extra) != 0 {
+			t.Errorf("unexpected member-identity-resolution Search calls: %v", extra)
+		}
+
+		// Invariant 3 (consistency guard): member_details in the saved
+		// state must remain exactly what the plan already had.
+		gotDetails := extractMemberDetails(t, ctx, out.MemberDetails)
+		wantDetails := extractMemberDetails(t, ctx, planModel.MemberDetails)
+		if len(gotDetails) != len(wantDetails) {
+			t.Fatalf("member_details = %v, want %v", gotDetails, wantDetails)
+		}
+		for dn, guid := range wantDetails {
+			if gotDetails[dn] != guid {
+				t.Errorf("member_details[%q] = %q, want %q (must equal plan's value verbatim)", dn, gotDetails[dn], guid)
+			}
+		}
+	})
+}
+
+// TestGroupMembershipResource_CreateUpdateFallBackWhenMemberDetailsUnknown
+// covers the EXCEPTION path: when member_details is Unknown at apply time
+// (ModifyPlan itself could not resolve members at plan time — e.g. `members`
+// depended on a computed attribute of another resource being created in the
+// very same apply, so its value only becomes known once that resource is
+// applied), Create/Update must fall back to resolving `members` fresh
+// (resolveMembersForWriteFallback) rather than trying to unpack an
+// Unknown/Null member_details. Since data.Members is fully known by the
+// time this fallback runs (the framework guarantees dependent apply-time
+// values are resolved before this resource's Create/Update executes), the
+// fallback's own live/cached resolution can succeed via a cache hit alone,
+// requiring no additional live Search either — exercised here by
+// pre-seeding the cache manager (mirroring the pattern in
+// TestGroupMembershipResource_ModifyPlanNeverMutatesMembers, which drives
+// this same "unknown" condition through ModifyPlan rather than directly
+// through Create/Update).
+//
+// Critically, the fallback must also backfill data.MemberDetails from the
+// fresh resolution before saving state: Terraform requires every computed
+// attribute to be fully known once apply completes, so member_details can
+// never be persisted as Unknown/Null.
+func TestGroupMembershipResource_CreateUpdateFallBackWhenMemberDetailsUnknown(t *testing.T) {
+	ctx := t.Context()
+
+	const (
+		memberDN   = "CN=ResolvedOnlyAtApplyTime,OU=Users,DC=example,DC=com"
+		memberGUID = "22222222-2222-2222-2222-222222222222"
+
+		groupGUID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+		groupDN   = "CN=OtherTestGroup,OU=Groups,DC=example,DC=com"
+	)
+
+	expectedAltDN, err := ldapclient.GUIDToAltDN(memberGUID)
+	if err != nil {
+		t.Fatalf("failed to compute expected alt-DN: %v", err)
+	}
+
+	t.Run("Create", func(t *testing.T) {
+		cm := ldapclient.NewCacheManager()
+		seedMembershipCache(t, cm, memberDN, memberGUID)
+
+		client := newRecordingMembershipClient(groupGUID, groupDN) // no members yet
+		r := newTestGroupMembershipResourceWithClient(client, cm)
+
+		planModel := &GroupMembershipResourceModel{
+			ID:                   types.StringUnknown(),
+			GroupID:              types.StringValue(groupGUID),
+			Members:              newMembershipSet(t, memberDN),
+			MemberDetails:        types.SetUnknown(memberDetailObjectType), // ModifyPlan could not resolve at plan time
+			IgnoreMissingMembers: types.BoolNull(),
+		}
+
+		out, resp := runMembershipCreate(t, ctx, r, planModel)
+		if resp.Diagnostics.HasError() {
+			t.Fatalf("unexpected error: %v", resp.Diagnostics.Errors())
+		}
+
+		added := client.addedMemberValues()
+		if len(added) != 1 || added[0] != expectedAltDN {
+			t.Errorf("AD write used %v, want [%q] (fallback-resolved GUID-alt-DN form)", added, expectedAltDN)
+		}
+
+		// The fallback resolved via a cache hit; no live Search needed.
+		if extra := client.nonGroupLookupSearches(); len(extra) != 0 {
+			t.Errorf("unexpected live Search calls during fallback resolution: %v", extra)
+		}
+
+		// member_details must never be left Unknown/Null in the saved
+		// state — it must be backfilled from the fallback resolution.
+		if out.MemberDetails.IsUnknown() || out.MemberDetails.IsNull() {
+			t.Fatalf("member_details left Unknown/Null after apply: %v", out.MemberDetails)
+		}
+		gotDetails := extractMemberDetails(t, ctx, out.MemberDetails)
+		wantDetails := map[string]string{memberDN: memberGUID}
+		if len(gotDetails) != len(wantDetails) || gotDetails[memberDN] != memberGUID {
+			t.Errorf("member_details = %v, want %v", gotDetails, wantDetails)
+		}
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		cm := ldapclient.NewCacheManager()
+		seedMembershipCache(t, cm, memberDN, memberGUID)
+
+		const dnOld = "CN=OldMember,OU=Users,DC=example,DC=com"
+		client := newRecordingMembershipClient(groupGUID, groupDN, dnOld)
+		r := newTestGroupMembershipResourceWithClient(client, cm)
+
+		planModel := &GroupMembershipResourceModel{
+			ID:                   types.StringValue(groupGUID),
+			GroupID:              types.StringValue(groupGUID),
+			Members:              newMembershipSet(t, memberDN),
+			MemberDetails:        types.SetUnknown(memberDetailObjectType),
+			IgnoreMissingMembers: types.BoolNull(),
+		}
+		stateModel := &GroupMembershipResourceModel{
+			ID:                   types.StringValue(groupGUID),
+			GroupID:              types.StringValue(groupGUID),
+			Members:              newMembershipSet(t, dnOld),
+			MemberDetails:        newMemberDetailSet(t, ctx, []string{dnOld}, []string{""}),
+			IgnoreMissingMembers: types.BoolNull(),
+		}
+
+		out, resp := runMembershipUpdate(t, ctx, r, planModel, stateModel)
+		if resp.Diagnostics.HasError() {
+			t.Fatalf("unexpected error: %v", resp.Diagnostics.Errors())
+		}
+
+		added := client.addedMemberValues()
+		if len(added) != 1 || added[0] != expectedAltDN {
+			t.Errorf("AD write used %v, want [%q] (fallback-resolved GUID-alt-DN form)", added, expectedAltDN)
+		}
+
+		if len(client.members) != 1 || client.members[0] != expectedAltDN {
+			t.Errorf("final group membership = %v, want [%q]", client.members, expectedAltDN)
+		}
+
+		if extra := client.nonGroupLookupSearches(); len(extra) != 0 {
+			t.Errorf("unexpected live Search calls during fallback resolution: %v", extra)
+		}
+
+		if out.MemberDetails.IsUnknown() || out.MemberDetails.IsNull() {
+			t.Fatalf("member_details left Unknown/Null after apply: %v", out.MemberDetails)
+		}
+		gotDetails := extractMemberDetails(t, ctx, out.MemberDetails)
+		wantDetails := map[string]string{memberDN: memberGUID}
+		if len(gotDetails) != len(wantDetails) || gotDetails[memberDN] != memberGUID {
+			t.Errorf("member_details = %v, want %v", gotDetails, wantDetails)
+		}
+	})
+}

--- a/internal/provider/resource_group_membership_apply_test.go
+++ b/internal/provider/resource_group_membership_apply_test.go
@@ -285,7 +285,7 @@ func (c *recordingMembershipClient) nonGroupLookupSearches() []string {
 // string.
 //
 // Each subtest hand-constructs a model where MemberDetails already holds a
-// resolved (dn, guid) pair whose dn deliberately looks "stale", as if
+// resolved (dn, id) pair whose dn deliberately looks "stale", as if
 // captured before some unrelated rename — and deliberately does NOT seed
 // the cache manager for that identifier. recordingMembershipClient fails
 // loudly on any Search beyond the legitimate group-by-GUID lookup, so if

--- a/internal/provider/resource_group_membership_internal_test.go
+++ b/internal/provider/resource_group_membership_internal_test.go
@@ -104,6 +104,7 @@ func seedMembershipCache(t *testing.T, cm *ldapclient.CacheManager, dn, guid str
 }
 
 // newMembershipSet builds a types.Set of strings, failing the test on error.
+// Used for the flat `members` attribute.
 func newMembershipSet(t *testing.T, values ...string) types.Set {
 	t.Helper()
 	elems := make([]attr.Value, 0, len(values))
@@ -118,7 +119,8 @@ func newMembershipSet(t *testing.T, values ...string) types.Set {
 }
 
 // extractSortedMembers extracts the string elements of a types.Set, sorted
-// for order-independent comparison. Null/unknown sets extract to nil.
+// for order-independent comparison. Null/unknown sets extract to nil. Used
+// for the flat `members` attribute.
 func extractSortedMembers(t *testing.T, ctx context.Context, s types.Set) []string {
 	t.Helper()
 	if s.IsNull() || s.IsUnknown() {
@@ -128,6 +130,65 @@ func extractSortedMembers(t *testing.T, ctx context.Context, s types.Set) []stri
 	diags := s.ElementsAs(ctx, &out, false)
 	if diags.HasError() {
 		t.Fatalf("failed to extract members: %v", diags.Errors())
+	}
+	sort.Strings(out)
+	return out
+}
+
+// newMemberDetailSet builds a types.Set of `member_details` {dn, guid}
+// objects from parallel dn/guid slices (same length, same order), failing
+// the test on error.
+func newMemberDetailSet(t *testing.T, ctx context.Context, dns, guids []string) types.Set {
+	t.Helper()
+	if len(dns) != len(guids) {
+		t.Fatalf("newMemberDetailSet: dns and guids must be the same length, got %d and %d", len(dns), len(guids))
+	}
+	details := make([]MemberDetailModel, 0, len(dns))
+	for i, dn := range dns {
+		details = append(details, MemberDetailModel{
+			DN:   types.StringValue(dn),
+			GUID: types.StringValue(guids[i]),
+		})
+	}
+	s, diags := types.SetValueFrom(ctx, memberDetailObjectType, details)
+	if diags.HasError() {
+		t.Fatalf("failed to build member_details set: %v", diags.Errors())
+	}
+	return s
+}
+
+// extractMemberDetails extracts the {dn, guid} elements of a `member_details`
+// types.Set into a dn->guid map, for order-independent comparison. Null/
+// unknown sets extract to nil.
+func extractMemberDetails(t *testing.T, ctx context.Context, s types.Set) map[string]string {
+	t.Helper()
+	if s.IsNull() || s.IsUnknown() {
+		return nil
+	}
+	var details []MemberDetailModel
+	diags := s.ElementsAs(ctx, &details, false)
+	if diags.HasError() {
+		t.Fatalf("failed to extract member details: %v", diags.Errors())
+	}
+	out := make(map[string]string, len(details))
+	for _, d := range details {
+		out[d.DN.ValueString()] = d.GUID.ValueString()
+	}
+	return out
+}
+
+// extractSortedMemberDetailDNs extracts just the `dn` field of each element
+// of a `member_details` types.Set, sorted for order-independent comparison.
+// Null/unknown sets extract to nil.
+func extractSortedMemberDetailDNs(t *testing.T, ctx context.Context, s types.Set) []string {
+	t.Helper()
+	pairs := extractMemberDetails(t, ctx, s)
+	if pairs == nil {
+		return nil
+	}
+	out := make([]string, 0, len(pairs))
+	for dn := range pairs {
+		out = append(out, dn)
 	}
 	sort.Strings(out)
 	return out
@@ -194,7 +255,7 @@ func runMembershipModifyPlan(
 // Invariant under test: ModifyPlan must never mutate `members` — the
 // resulting plan's `members` attribute must always equal the input plan's
 // `members` attribute verbatim (order-independent), regardless of prior
-// state. Only `members_normalized` may be (and must be) derived/updated.
+// state. Only `member_details` may be (and must be) derived/updated.
 func TestGroupMembershipResource_ModifyPlanNeverMutatesMembers(t *testing.T) {
 	ctx := t.Context()
 
@@ -231,14 +292,14 @@ func TestGroupMembershipResource_ModifyPlanNeverMutatesMembers(t *testing.T) {
 			ID:                   types.StringValue(groupID),
 			GroupID:              types.StringValue(groupID),
 			Members:              newMembershipSet(t, guid1, guid2, guid3),
-			MembersNormalized:    types.SetUnknown(types.StringType),
+			MemberDetails:        types.SetUnknown(memberDetailObjectType),
 			IgnoreMissingMembers: types.BoolNull(),
 		}
 		stateModel := &GroupMembershipResourceModel{
 			ID:                   types.StringValue(groupID),
 			GroupID:              types.StringValue(groupID),
 			Members:              newMembershipSet(t, dn1, dn2),
-			MembersNormalized:    newMembershipSet(t, dn1, dn2),
+			MemberDetails:        newMemberDetailSet(t, ctx, []string{dn1, dn2}, []string{guid1, guid2}),
 			IgnoreMissingMembers: types.BoolNull(),
 		}
 
@@ -249,11 +310,15 @@ func TestGroupMembershipResource_ModifyPlanNeverMutatesMembers(t *testing.T) {
 
 		assertMembersVerbatim(t, ctx, planModel.Members, out.Members)
 
-		gotNormalized := extractSortedMembers(t, ctx, out.MembersNormalized)
-		wantNormalized := []string{dn1, dn2, dn3}
-		sort.Strings(wantNormalized)
-		if !slices.Equal(gotNormalized, wantNormalized) {
-			t.Errorf("members_normalized = %v, want %v", gotNormalized, wantNormalized)
+		gotDetails := extractMemberDetails(t, ctx, out.MemberDetails)
+		wantDetails := map[string]string{dn1: guid1, dn2: guid2, dn3: guid3}
+		if len(gotDetails) != len(wantDetails) {
+			t.Fatalf("member_details = %v, want %v", gotDetails, wantDetails)
+		}
+		for dn, guid := range wantDetails {
+			if gotDetails[dn] != guid {
+				t.Errorf("member_details[%q] = %q, want %q", dn, gotDetails[dn], guid)
+			}
 		}
 	})
 
@@ -268,7 +333,7 @@ func TestGroupMembershipResource_ModifyPlanNeverMutatesMembers(t *testing.T) {
 			ID:                   types.StringUnknown(),
 			GroupID:              types.StringValue(groupID),
 			Members:              newMembershipSet(t, guid1, guid2),
-			MembersNormalized:    types.SetUnknown(types.StringType),
+			MemberDetails:        types.SetUnknown(memberDetailObjectType),
 			IgnoreMissingMembers: types.BoolNull(),
 		}
 
@@ -279,11 +344,11 @@ func TestGroupMembershipResource_ModifyPlanNeverMutatesMembers(t *testing.T) {
 
 		assertMembersVerbatim(t, ctx, planModel.Members, out.Members)
 
-		gotNormalized := extractSortedMembers(t, ctx, out.MembersNormalized)
+		gotNormalized := extractSortedMemberDetailDNs(t, ctx, out.MemberDetails)
 		wantNormalized := []string{dn1, dn2}
 		sort.Strings(wantNormalized)
 		if !slices.Equal(gotNormalized, wantNormalized) {
-			t.Errorf("members_normalized = %v, want %v", gotNormalized, wantNormalized)
+			t.Errorf("member_details dns = %v, want %v", gotNormalized, wantNormalized)
 		}
 	})
 
@@ -298,14 +363,14 @@ func TestGroupMembershipResource_ModifyPlanNeverMutatesMembers(t *testing.T) {
 			ID:                   types.StringValue(groupID),
 			GroupID:              types.StringValue(groupID),
 			Members:              newMembershipSet(t, dn1, dn2),
-			MembersNormalized:    types.SetUnknown(types.StringType),
+			MemberDetails:        types.SetUnknown(memberDetailObjectType),
 			IgnoreMissingMembers: types.BoolNull(),
 		}
 		stateModel := &GroupMembershipResourceModel{
 			ID:                   types.StringValue(groupID),
 			GroupID:              types.StringValue(groupID),
 			Members:              newMembershipSet(t, dn1, dn2),
-			MembersNormalized:    newMembershipSet(t, dn1, dn2),
+			MemberDetails:        newMemberDetailSet(t, ctx, []string{dn1, dn2}, []string{guid1, guid2}),
 			IgnoreMissingMembers: types.BoolNull(),
 		}
 
@@ -328,14 +393,14 @@ func TestGroupMembershipResource_ModifyPlanNeverMutatesMembers(t *testing.T) {
 			ID:                   types.StringValue(groupID),
 			GroupID:              types.StringValue(groupID),
 			Members:              newMembershipSet(t, guid1, guid2),
-			MembersNormalized:    types.SetUnknown(types.StringType),
+			MemberDetails:        types.SetUnknown(memberDetailObjectType),
 			IgnoreMissingMembers: types.BoolNull(),
 		}
 		stateModel := &GroupMembershipResourceModel{
 			ID:                   types.StringValue(groupID),
 			GroupID:              types.StringValue(groupID),
 			Members:              newMembershipSet(t, dn1, dn2),
-			MembersNormalized:    newMembershipSet(t, dn1, dn2),
+			MemberDetails:        newMemberDetailSet(t, ctx, []string{dn1, dn2}, []string{guid1, guid2}),
 			IgnoreMissingMembers: types.BoolNull(),
 		}
 
@@ -364,7 +429,7 @@ func TestGroupMembershipResource_ModifyPlanNeverMutatesMembers(t *testing.T) {
 			ID:                   types.StringUnknown(),
 			GroupID:              types.StringUnknown(),
 			Members:              newMembershipSet(t, guid1),
-			MembersNormalized:    types.SetUnknown(types.StringType),
+			MemberDetails:        types.SetUnknown(memberDetailObjectType),
 			IgnoreMissingMembers: types.BoolNull(),
 		}
 
@@ -375,8 +440,149 @@ func TestGroupMembershipResource_ModifyPlanNeverMutatesMembers(t *testing.T) {
 
 		assertMembersVerbatim(t, ctx, planModel.Members, out.Members)
 
-		if !out.MembersNormalized.IsUnknown() {
-			t.Errorf("expected members_normalized to be unknown when group_id is unknown, got %v", out.MembersNormalized)
+		if !out.MemberDetails.IsUnknown() {
+			t.Errorf("expected member_details to be unknown when group_id is unknown, got %v", out.MemberDetails)
 		}
 	})
+}
+
+// TestGroupMembershipResource_ModifyPlanUnknownMembersDetail is a focused
+// regression guard for the "member_details must be Unknown, as a whole, when
+// `members` itself is unknown" branch of ModifyPlan — mirroring the same
+// unknown-members scenario already covered inside
+// TestGroupMembershipResource_ModifyPlanNeverMutatesMembers's "unknown
+// group_id" subtest, but isolating the case where group_id IS known and it
+// is specifically `members` that is unknown (e.g. it references an
+// attribute of a resource being created in the very same apply). This is
+// also exactly the condition that later forces Create/Update's apply-time
+// fallback path (see resolveMemberDetailsForWrite in
+// resource_group_membership.go and
+// TestGroupMembershipResource_CreateUpdateFallBackWhenMemberDetailsUnknown
+// in resource_group_membership_apply_test.go).
+func TestGroupMembershipResource_ModifyPlanUnknownMembersDetail(t *testing.T) {
+	ctx := t.Context()
+
+	const groupID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+	cm := ldapclient.NewCacheManager()
+	r := newTestGroupMembershipResource(cm)
+
+	planModel := &GroupMembershipResourceModel{
+		ID:                   types.StringValue(groupID),
+		GroupID:              types.StringValue(groupID),
+		Members:              types.SetUnknown(types.StringType),
+		MemberDetails:        types.SetUnknown(memberDetailObjectType),
+		IgnoreMissingMembers: types.BoolNull(),
+	}
+
+	out, resp := runMembershipModifyPlan(t, ctx, r, planModel, nil)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %v", resp.Diagnostics.Errors())
+	}
+
+	if !out.MemberDetails.IsUnknown() {
+		t.Errorf("expected member_details to be unknown (as a whole) when members is unknown, got %v", out.MemberDetails)
+	}
+}
+
+// TestGroupMembershipResource_ModifyPlanResolvesEveryIdentifierFormat proves
+// that ModifyPlan populates `member_details` with the correct (dn, guid)
+// pair for every supported `members` identifier format — DN, GUID, SID,
+// UPN, and SAM — each resolved via a cache-seeded entry (no live LDAP
+// call), following the same direct-ModifyPlan-invocation and cache-seeding
+// conventions as TestGroupMembershipResource_ModifyPlanNeverMutatesMembers.
+func TestGroupMembershipResource_ModifyPlanResolvesEveryIdentifierFormat(t *testing.T) {
+	ctx := t.Context()
+
+	const (
+		groupID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+		// dnFormat is used AS the `members` identifier verbatim (it IS
+		// already a DN), so resolving it is a validateDN cache hit.
+		dnFormat = "CN=DNMember,OU=Users,DC=example,DC=com"
+		guidOfDN = "11111111-1111-1111-1111-111111111111"
+
+		guidMember     = "22222222-2222-2222-2222-222222222222"
+		dnOfGUIDMember = "CN=GUIDMember,OU=Users,DC=example,DC=com"
+
+		sidMember     = "S-1-5-21-123456789-123456789-123456789-1001"
+		dnOfSIDMember = "CN=SIDMember,OU=Users,DC=example,DC=com"
+		guidOfSID     = "33333333-3333-3333-3333-333333333333"
+
+		upnMember = "upnmember@example.com"
+		dnOfUPN   = "CN=UPNMember,OU=Users,DC=example,DC=com"
+		guidOfUPN = "44444444-4444-4444-4444-444444444444"
+
+		samMember = "DOMAIN\\SAMMember"
+		dnOfSAM   = "CN=SAMMember,OU=Users,DC=example,DC=com"
+		guidOfSAM = "55555555-5555-5555-5555-555555555555"
+	)
+
+	cm := ldapclient.NewCacheManager()
+	// Seed by the identifier the cache will actually be queried with:
+	// MemberNormalizer.Resolve checks the cache using the (trimmed) input
+	// identifier first, so each entry below is keyed appropriately —
+	// seedMembershipCache's DN/GUID pair is enough because CacheManager.Get
+	// resolves via any indexed key (DN, GUID, SID, UPN, SAM) that Put
+	// recorded for the entry, and validateDN/resolveGUID/etc. all populate
+	// the full LDAPCacheEntry (including SID/UPN/SAM-specific fields) when
+	// caching a live resolution. Since these tests must never hit Search,
+	// we instead seed one full entry per member covering every index the
+	// resolver for that identifier's type will look up.
+	seedMembershipCache(t, cm, dnFormat, guidOfDN)
+	seedMembershipCache(t, cm, dnOfGUIDMember, guidMember)
+	if err := cm.Put(&ldapclient.LDAPCacheEntry{
+		DN:         dnOfSIDMember,
+		ObjectGUID: guidOfSID,
+		ObjectSID:  sidMember,
+		Attributes: map[string][]string{},
+	}); err != nil {
+		t.Fatalf("failed to seed SID cache entry: %v", err)
+	}
+	if err := cm.Put(&ldapclient.LDAPCacheEntry{
+		DN:         dnOfUPN,
+		ObjectGUID: guidOfUPN,
+		Attributes: map[string][]string{"userPrincipalName": {upnMember}},
+	}); err != nil {
+		t.Fatalf("failed to seed UPN cache entry: %v", err)
+	}
+	if err := cm.Put(&ldapclient.LDAPCacheEntry{
+		DN:         dnOfSAM,
+		ObjectGUID: guidOfSAM,
+		Attributes: map[string][]string{"sAMAccountName": {"SAMMember"}},
+	}); err != nil {
+		t.Fatalf("failed to seed SAM cache entry: %v", err)
+	}
+
+	r := newTestGroupMembershipResource(cm)
+
+	planModel := &GroupMembershipResourceModel{
+		ID:                   types.StringValue(groupID),
+		GroupID:              types.StringValue(groupID),
+		Members:              newMembershipSet(t, dnFormat, guidMember, sidMember, upnMember, samMember),
+		MemberDetails:        types.SetUnknown(memberDetailObjectType),
+		IgnoreMissingMembers: types.BoolNull(),
+	}
+
+	out, resp := runMembershipModifyPlan(t, ctx, r, planModel, nil)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %v", resp.Diagnostics.Errors())
+	}
+
+	got := extractMemberDetails(t, ctx, out.MemberDetails)
+	want := map[string]string{
+		dnFormat:       guidOfDN,
+		dnOfGUIDMember: guidMember,
+		dnOfSIDMember:  guidOfSID,
+		dnOfUPN:        guidOfUPN,
+		dnOfSAM:        guidOfSAM,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("member_details = %v, want %v", got, want)
+	}
+	for dn, guid := range want {
+		if got[dn] != guid {
+			t.Errorf("member_details[%q] = %q, want %q", dn, got[dn], guid)
+		}
+	}
 }

--- a/internal/provider/resource_group_membership_internal_test.go
+++ b/internal/provider/resource_group_membership_internal_test.go
@@ -135,7 +135,7 @@ func extractSortedMembers(t *testing.T, ctx context.Context, s types.Set) []stri
 	return out
 }
 
-// newMemberDetailSet builds a types.Set of `member_details` {dn, guid}
+// newMemberDetailSet builds a types.Set of `member_details` {dn, id}
 // objects from parallel dn/guid slices (same length, same order), failing
 // the test on error.
 func newMemberDetailSet(t *testing.T, ctx context.Context, dns, guids []string) types.Set {
@@ -146,8 +146,8 @@ func newMemberDetailSet(t *testing.T, ctx context.Context, dns, guids []string) 
 	details := make([]MemberDetailModel, 0, len(dns))
 	for i, dn := range dns {
 		details = append(details, MemberDetailModel{
-			DN:   types.StringValue(dn),
-			GUID: types.StringValue(guids[i]),
+			DN: types.StringValue(dn),
+			ID: types.StringValue(guids[i]),
 		})
 	}
 	s, diags := types.SetValueFrom(ctx, memberDetailObjectType, details)
@@ -157,7 +157,7 @@ func newMemberDetailSet(t *testing.T, ctx context.Context, dns, guids []string) 
 	return s
 }
 
-// extractMemberDetails extracts the {dn, guid} elements of a `member_details`
+// extractMemberDetails extracts the {dn, id} elements of a `member_details`
 // types.Set into a dn->guid map, for order-independent comparison. Null/
 // unknown sets extract to nil.
 func extractMemberDetails(t *testing.T, ctx context.Context, s types.Set) map[string]string {
@@ -172,7 +172,7 @@ func extractMemberDetails(t *testing.T, ctx context.Context, s types.Set) map[st
 	}
 	out := make(map[string]string, len(details))
 	for _, d := range details {
-		out[d.DN.ValueString()] = d.GUID.ValueString()
+		out[d.DN.ValueString()] = d.ID.ValueString()
 	}
 	return out
 }
@@ -486,7 +486,7 @@ func TestGroupMembershipResource_ModifyPlanUnknownMembersDetail(t *testing.T) {
 }
 
 // TestGroupMembershipResource_ModifyPlanResolvesEveryIdentifierFormat proves
-// that ModifyPlan populates `member_details` with the correct (dn, guid)
+// that ModifyPlan populates `member_details` with the correct (dn, id)
 // pair for every supported `members` identifier format — DN, GUID, SID,
 // UPN, and SAM — each resolved via a cache-seeded entry (no live LDAP
 // call), following the same direct-ModifyPlan-invocation and cache-seeding

--- a/internal/provider/resource_group_membership_rename_acc_test.go
+++ b/internal/provider/resource_group_membership_rename_acc_test.go
@@ -1,0 +1,172 @@
+package provider_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	ldapclient "github.com/isometry/terraform-provider-ad/internal/ldap"
+)
+
+// TestAccGroupMembershipResource_memberGroupRenamedAcrossApplies covers the
+// scenario the plan-time-GUID-capture design (see resource_group_membership.go's
+// `member_details` attribute and resolveMemberDetailsForWrite) is built to
+// handle safely: a member referenced by a rename-immune identifier (its
+// GUID) gets renamed underneath the membership resource, changing its DN.
+// Because `member_details` pairs that GUID with a DN, and AD writes prefer
+// the GUID's rename-immune "<GUID=...>" alternative-DN form whenever the
+// GUID is known, the membership resource's next refreshed plan must be
+// completely empty — no membership re-diff or rewrite, and no attempt to
+// rename the group back — regardless of whether the DN captured at some
+// earlier plan time is now stale.
+//
+// This test exercises the out-of-band variant of the scenario: rename the
+// member group directly via LDAP in PreConfig (simulating an external actor
+// or a separate Terraform apply), then assert the refreshed plan is
+// completely empty and a follow-up plan converges.
+//
+// The core correctness guarantee under test here — that the AD write always
+// uses member_details' captured GUID, and that Create/Update perform zero
+// LDAP calls to resolve member identity in the common case — is covered
+// directly (and more cheaply) by the unit tests in
+// resource_group_membership_apply_test.go
+// (TestGroupMembershipResource_CreateUpdateTrustPlanTimeMemberDetails),
+// which inject a "stale-looking" member_details DN directly and are not
+// subject to any acceptance-test harness limitations.
+func TestAccGroupMembershipResource_memberGroupRenamedAcrossApplies(t *testing.T) {
+	ctx := t.Context()
+	ou := GenerateTestName("tf-mship-ren-ou-")
+	memberGroupName := GenerateTestName("tf-mship-ren-member-")
+	memberGroupSAM := GenerateTestSAMName("TFMshRenM")
+	containerGroupName := GenerateTestName("tf-mship-ren-container-")
+	containerGroupSAM := GenerateTestSAMName("TFMshRenC")
+	renamedMemberGroupName := GenerateTestName("tf-mship-ren-member2-")
+
+	// Captured during Step 1's Check, so Step 2's PreConfig (which runs
+	// before the plan and has no access to state) can perform the rename.
+	var memberGroupGUID string
+
+	config := func(memberName string) string {
+		return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "ad_ou" "test" {
+  name        = %[3]q
+  path        = data.ad_rootdse.test.default_naming_context
+  description = "Temporary OU for ad_group_membership rename acceptance test"
+}
+
+resource "ad_group" "member" {
+  name             = %[4]q
+  sam_account_name = %[5]q
+  container        = ad_ou.test.dn
+  scope            = "global"
+  category         = "security"
+  description      = "Member group, renamed out-of-band in this test"
+}
+
+resource "ad_group" "container" {
+  name             = %[6]q
+  sam_account_name = %[7]q
+  container        = ad_ou.test.dn
+  scope            = "global"
+  category         = "security"
+  description      = "Container group whose membership references ad_group.member by GUID"
+}
+
+resource "ad_group_membership" "test" {
+  group_id = ad_group.container.id
+  members = [
+    ad_group.member.id, # rename-immune GUID reference
+  ]
+}
+`,
+			testProviderConfig(),
+			testRootDSEDataSource(),
+			ou,
+			memberName, memberGroupSAM,
+			containerGroupName, containerGroupSAM,
+		)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: create the member group, container group, and the
+			// membership resource referencing the member group by GUID.
+			// Capture the member group's GUID for Step 2's PreConfig.
+			{
+				Config: config(memberGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ad_group_membership.test", "members.#", "1"),
+					resource.TestCheckResourceAttr("ad_group_membership.test", "member_details.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(
+						"ad_group_membership.test", "members.*",
+						"ad_group.member", "id",
+					),
+					captureStateAttr("ad_group.member", "id", &memberGroupGUID),
+				),
+			},
+			// Step 2: rename the member group out-of-band via LDAP (its
+			// GUID, and therefore the membership reference, is unaffected;
+			// only its DN changes), then plan against a config that matches
+			// the post-rename reality. The refreshed plan must contain ZERO
+			// actions: refresh reconciles both ad_group.member (name already
+			// matches) and the membership's member_details snapshot, and
+			// the membership must not re-diff or attempt to rewrite anything
+			// just because the referenced group's DN changed underneath it.
+			{
+				PreConfig: func() {
+					if err := renameGroupOutOfBand(ctx, memberGroupGUID, renamedMemberGroupName); err != nil {
+						t.Fatalf("failed to rename member group out-of-band: %v", err)
+					}
+				},
+				Config: config(renamedMemberGroupName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ad_group.member", "name", renamedMemberGroupName),
+					resource.TestCheckResourceAttr("ad_group_membership.test", "members.#", "1"),
+					resource.TestCheckResourceAttr("ad_group_membership.test", "member_details.#", "1"),
+				),
+			},
+			// Step 3: re-planning the same (post-rename) config must
+			// converge to a clean, empty plan for the membership resource —
+			// no drift, no attempted rewrite, despite the referenced
+			// group's DN having changed underneath it.
+			{
+				Config:   config(renamedMemberGroupName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// renameGroupOutOfBand renames a group directly via the ldap package,
+// bypassing Terraform — simulating a rename performed by an external actor
+// or a separate Terraform apply.
+func renameGroupOutOfBand(ctx context.Context, groupGUID, newName string) error {
+	config := GetTestConfig()
+	ldapConfig := newTestLDAPConfig(config)
+
+	client, err := ldapclient.NewClient(ctx, ldapConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create LDAP client: %w", err)
+	}
+	defer client.Close()
+
+	gm := ldapclient.NewGroupManager(ctx, client, config.BaseDN, ldapclient.NewCacheManager())
+	if _, err := gm.UpdateGroup(groupGUID, &ldapclient.UpdateGroupRequest{Name: &newName}); err != nil {
+		return fmt.Errorf("failed to rename group %s to %q: %w", groupGUID, newName, err)
+	}
+	return nil
+}

--- a/internal/provider/resource_group_membership_test.go
+++ b/internal/provider/resource_group_membership_test.go
@@ -182,7 +182,7 @@ func TestAccGroupMembershipResource_basic(t *testing.T) {
 // strictly verbatim passthrough of configuration: switching an existing
 // member's identifier format (DN -> UPN -> GUID) for the very same AD
 // principal is a real, expected plan diff on `members` (never silently
-// reconciled), while `members_normalized` (and therefore actual AD
+// reconciled), while `member_details` (and therefore actual AD
 // membership) does not change across the format switch. Each format switch
 // converges to an empty plan on the next apply.
 func TestAccGroupMembershipResource_antiDrift(t *testing.T) {
@@ -197,7 +197,7 @@ func TestAccGroupMembershipResource_antiDrift(t *testing.T) {
 				Config: testAccGroupMembershipResourceConfig_antiDriftDN(n),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ad_group_membership.test", "members.#", "1"),
-					resource.TestCheckResourceAttr("ad_group_membership.test", "members_normalized.#", "1"),
+					resource.TestCheckResourceAttr("ad_group_membership.test", "member_details.#", "1"),
 				),
 			},
 			// Switching to UPN format for the same user is a real change to
@@ -209,13 +209,13 @@ func TestAccGroupMembershipResource_antiDrift(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			// Apply the UPN format: `members` must now hold the UPN
-			// verbatim, while `members_normalized` (actual AD membership) is
+			// verbatim, while `member_details` (actual AD membership) is
 			// unchanged.
 			{
 				Config: testAccGroupMembershipResourceConfig_antiDriftUPN(n),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ad_group_membership.test", "members.#", "1"),
-					resource.TestCheckResourceAttr("ad_group_membership.test", "members_normalized.#", "1"),
+					resource.TestCheckResourceAttr("ad_group_membership.test", "member_details.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(
 						"ad_group_membership.test", "members.*",
 						"ad_user.testuser1", "principal_name",
@@ -235,13 +235,13 @@ func TestAccGroupMembershipResource_antiDrift(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			// Apply the GUID format: `members` must now hold the GUID
-			// verbatim, while `members_normalized` (actual AD membership) is
+			// verbatim, while `member_details` (actual AD membership) is
 			// unchanged.
 			{
 				Config: testAccGroupMembershipResourceConfig_antiDriftGUID(n),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ad_group_membership.test", "members.#", "1"),
-					resource.TestCheckResourceAttr("ad_group_membership.test", "members_normalized.#", "1"),
+					resource.TestCheckResourceAttr("ad_group_membership.test", "member_details.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(
 						"ad_group_membership.test", "members.*",
 						"ad_user.testuser1", "id",
@@ -271,7 +271,7 @@ func TestAccGroupMembershipResource_mixedIdentifiers(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ad_group_membership.test", "members.#", "3"),
 					// All should normalize to the same set of DNs
-					resource.TestCheckResourceAttr("ad_group_membership.test", "members_normalized.#", "3"),
+					resource.TestCheckResourceAttr("ad_group_membership.test", "member_details.#", "3"),
 				),
 			},
 		},
@@ -298,7 +298,7 @@ func mangleDNCase(dn string) string {
 // is a strictly verbatim passthrough of configuration: changing only the DN
 // attribute-type case (e.g. `cn=` -> `Cn=`) for the same member is a real,
 // expected plan diff on `members` (never silently reconciled), even though
-// the underlying AD principal - and therefore `members_normalized` - is
+// the underlying AD principal - and therefore `member_details` - is
 // unchanged. Each case change converges to an empty plan on the next apply.
 func TestAccGroupMembershipResource_dnCaseNormalization(t *testing.T) {
 	n := newGMTestNames(0)
@@ -314,7 +314,7 @@ func TestAccGroupMembershipResource_dnCaseNormalization(t *testing.T) {
 				Config: testAccGroupMembershipResourceConfig_lowercaseDN(n),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ad_group_membership.test", "members.#", "1"),
-					resource.TestCheckResourceAttr("ad_group_membership.test", "members_normalized.#", "1"),
+					resource.TestCheckResourceAttr("ad_group_membership.test", "member_details.#", "1"),
 					captureStateAttr("ad_user.testuser1", "dn", &testUser1DN),
 				),
 			},
@@ -328,13 +328,13 @@ func TestAccGroupMembershipResource_dnCaseNormalization(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			// Apply the mixed-case DN: `members` must now hold the
-			// mixed-case value verbatim, while `members_normalized` (actual
+			// mixed-case value verbatim, while `member_details` (actual
 			// AD membership) is unchanged.
 			{
 				Config: testAccGroupMembershipResourceConfig_mixedCaseDN(n),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ad_group_membership.test", "members.#", "1"),
-					resource.TestCheckResourceAttr("ad_group_membership.test", "members_normalized.#", "1"),
+					resource.TestCheckResourceAttr("ad_group_membership.test", "member_details.#", "1"),
 					func(s *terraform.State) error {
 						return resource.TestCheckTypeSetElemAttr(
 							"ad_group_membership.test", "members.*", mangleDNCase(testUser1DN),
@@ -356,12 +356,12 @@ func TestAccGroupMembershipResource_dnCaseNormalization(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			// Apply the lowercase DN again: `members` reflects it verbatim,
-			// and `members_normalized` (actual AD membership) is unchanged.
+			// and `member_details` (actual AD membership) is unchanged.
 			{
 				Config: testAccGroupMembershipResourceConfig_lowercaseDN(n),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ad_group_membership.test", "members.#", "1"),
-					resource.TestCheckResourceAttr("ad_group_membership.test", "members_normalized.#", "1"),
+					resource.TestCheckResourceAttr("ad_group_membership.test", "member_details.#", "1"),
 					func(s *terraform.State) error {
 						return resource.TestCheckTypeSetElemAttr(
 							"ad_group_membership.test", "members.*", strings.ToLower(testUser1DN),
@@ -404,7 +404,7 @@ func TestAccGroupMembershipResource_membersVerbatimNoInvalidPlan(t *testing.T) {
 				Config: testAccGroupMembershipResourceConfig_verbatimTransitionDN(n),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ad_group_membership.test", "members.#", "2"),
-					resource.TestCheckResourceAttr("ad_group_membership.test", "members_normalized.#", "2"),
+					resource.TestCheckResourceAttr("ad_group_membership.test", "member_details.#", "2"),
 				),
 			},
 			// Reconfigure using GUIDs for the existing two members plus a
@@ -418,7 +418,7 @@ func TestAccGroupMembershipResource_membersVerbatimNoInvalidPlan(t *testing.T) {
 				Config: testAccGroupMembershipResourceConfig_verbatimTransitionGUID(n),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ad_group_membership.test", "members.#", "3"),
-					resource.TestCheckResourceAttr("ad_group_membership.test", "members_normalized.#", "3"),
+					resource.TestCheckResourceAttr("ad_group_membership.test", "member_details.#", "3"),
 					// `members` must equal the configured GUIDs verbatim.
 					resource.TestCheckTypeSetElemAttrPair(
 						"ad_group_membership.test", "members.*",
@@ -432,18 +432,18 @@ func TestAccGroupMembershipResource_membersVerbatimNoInvalidPlan(t *testing.T) {
 						"ad_group_membership.test", "members.*",
 						"ad_user.testuser3", "id",
 					),
-					// `members_normalized` must equal the resolved DNs for
+					// `member_details` must contain the resolved DNs for
 					// all three members (old + new).
 					resource.TestCheckTypeSetElemAttrPair(
-						"ad_group_membership.test", "members_normalized.*",
+						"ad_group_membership.test", "member_details.*.dn",
 						"ad_user.testuser1", "dn",
 					),
 					resource.TestCheckTypeSetElemAttrPair(
-						"ad_group_membership.test", "members_normalized.*",
+						"ad_group_membership.test", "member_details.*.dn",
 						"ad_user.testuser2", "dn",
 					),
 					resource.TestCheckTypeSetElemAttrPair(
-						"ad_group_membership.test", "members_normalized.*",
+						"ad_group_membership.test", "member_details.*.dn",
 						"ad_user.testuser3", "dn",
 					),
 				),
@@ -488,7 +488,7 @@ resource "ad_group_membership" "test" {
 }
 
 // Members declared with surrounding whitespace must apply cleanly, populate
-// members_normalized with the trimmed canonical DNs, and produce zero diff on
+// member_details with the trimmed canonical DNs, and produce zero diff on
 // re-plan.
 func TestAccGroupMembershipResource_WhitespaceTolerantMembers(t *testing.T) {
 	n := newGMTestNames(0)
@@ -501,7 +501,7 @@ func TestAccGroupMembershipResource_WhitespaceTolerantMembers(t *testing.T) {
 				Config: testAccGroupMembershipResourceConfig_whitespacePadded(n),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ad_group_membership.test", "members.#", "2"),
-					resource.TestCheckResourceAttr("ad_group_membership.test", "members_normalized.#", "2"),
+					resource.TestCheckResourceAttr("ad_group_membership.test", "member_details.#", "2"),
 				),
 			},
 			{
@@ -592,7 +592,7 @@ func TestAccGroupMembershipResource_unknownMembers(t *testing.T) {
 					// The filter group should have 2 member groups
 					resource.TestCheckResourceAttr("ad_group_membership.filter", "members.#", "2"),
 					resource.TestCheckResourceAttrSet("ad_group_membership.filter", "group_id"),
-					resource.TestCheckResourceAttrSet("ad_group_membership.filter", "members_normalized.#"),
+					resource.TestCheckResourceAttrSet("ad_group_membership.filter", "member_details.#"),
 				),
 			},
 		},
@@ -1422,7 +1422,7 @@ func driftGroupMembership(ctx context.Context, groupGUID string, toAdd, toRemove
 	mm := ldapclient.NewGroupMembershipManager(ctx, client, config.BaseDN, cacheManager)
 
 	if len(toAdd) > 0 {
-		if err := mm.AddGroupMembers(groupGUID, toAdd); err != nil {
+		if err := mm.AddGroupMembers(groupGUID, toAdd, nil); err != nil {
 			return fmt.Errorf("failed to add drift members: %w", err)
 		}
 	}
@@ -1442,7 +1442,7 @@ func checkMembershipContains(membershipRes string, userResources ...string) reso
 		if !ok {
 			return fmt.Errorf("resource not found: %s", membershipRes)
 		}
-		normalized := collectNormalizedMembers(membership.Primary.Attributes)
+		normalized := collectMemberDetailDNs(membership.Primary.Attributes)
 		for _, u := range userResources {
 			rs, ok := s.RootModule().Resources[u]
 			if !ok {
@@ -1465,7 +1465,7 @@ func checkMembershipExcludes(membershipRes string, userResources ...string) reso
 		if !ok {
 			return fmt.Errorf("resource not found: %s", membershipRes)
 		}
-		normalized := collectNormalizedMembers(membership.Primary.Attributes)
+		normalized := collectMemberDetailDNs(membership.Primary.Attributes)
 		for _, u := range userResources {
 			rs, ok := s.RootModule().Resources[u]
 			if !ok {
@@ -1480,12 +1480,12 @@ func checkMembershipExcludes(membershipRes string, userResources ...string) reso
 	}
 }
 
-// collectNormalizedMembers returns the members_normalized.* attribute values
+// collectMemberDetailDNs returns the member_details.*.dn attribute values
 // from a flat state-attribute map, lowercased for case-insensitive matching.
-func collectNormalizedMembers(attrs map[string]string) []string {
+func collectMemberDetailDNs(attrs map[string]string) []string {
 	var out []string
 	for k, v := range attrs {
-		if strings.HasPrefix(k, "members_normalized.") && k != "members_normalized.#" {
+		if strings.HasPrefix(k, "member_details.") && strings.HasSuffix(k, ".dn") {
 			out = append(out, strings.ToLower(v))
 		}
 	}

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -1036,7 +1036,7 @@ func (r *UserResource) ImportState(ctx context.Context, req resource.ImportState
 
 	// Normalize the import ID to a DN (supports DN, GUID, SID, UPN, SAM formats)
 	normalizer := ldapclient.NewMemberNormalizer(r.client, r.baseDN, r.cacheManager)
-	userDN, err := normalizer.NormalizeToDN(importID)
+	resolved, err := normalizer.Resolve(importID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Resolving User Identifier",
@@ -1044,6 +1044,7 @@ func (r *UserResource) ImportState(ctx context.Context, req resource.ImportState
 		)
 		return
 	}
+	userDN := resolved.DN
 
 	tflog.Debug(ctx, "Resolved user identifier to DN", map[string]any{
 		"import_id": importID,


### PR DESCRIPTION
A member group renamed by an unordered sibling resource within the same apply could cause ad_group_membership to write a stale, no-longer-valid DN to AD's `member` attribute, since Create/Update previously trusted a DN resolved at plan time (members_normalized).

Since an object's objectGUID never changes for its lifetime (unlike its DN, which changes on rename), members are now resolved once at plan time into a new computed `member_details` attribute (replacing members_normalized) - a set of {dn, guid} pairs, correlated at the schema level. Create/Update use member_details directly and write via AD's documented "<GUID=...>" alternative-DN form when available, making the write immune to rename regardless of apply ordering. Read/ImportState resolve each live member's GUID so member_details stays accurate across refreshes.

internal/ldap's identifier-resolution API (NormalizeToDN/ NormalizeToDNBatch/ResolveSIDToDN) is renamed and reshaped to Resolve/ResolveBatch/ResolveSID, returning ResolvedIdentifier{DN, GUID}, to support this without duplicating LDAP lookups.

BREAKING CHANGE: the calcutated `members_normalized` attribute of `ad_group_membership`, which contained a set of member DNs, is renamed to `member_details`, and contains a set of `{dn, guid}` maps.